### PR TITLE
5.5 VRM4U Extend Support to Mixamo, Meta-Human, and DAZ Skeletal Rigs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@
 *.exe
 *.out
 *.app
+/Binaries/
+/Intermediate/
+*.dll
+*.exp
+*.pdb

--- a/Source/VRM4U/Private/VrmAssetListObject.cpp
+++ b/Source/VRM4U/Private/VrmAssetListObject.cpp
@@ -69,15 +69,14 @@ void UVrmAssetListObject::CopyMember(UVrmAssetListObject *dst) const {
 }
 
 #if WITH_EDITOR
-void UVrmAssetListObject::GetAssetRegistryTags(TArray<FAssetRegistryTag>& OutTags) const
+void UVrmAssetListObject::GetAssetRegistryTags(FAssetRegistryTagsContext Context) const
 {
 	if (AssetImportData)
 	{
-		OutTags.Add(FAssetRegistryTag(SourceFileTagName(), AssetImportData->GetSourceData().ToJson(), FAssetRegistryTag::TT_Hidden));
-
-		OutTags.Add(FAssetRegistryTag("VRM4U", SourceFileTagName().ToString(), FAssetRegistryTag::TT_Hidden));
+		Context.AddTag(FAssetRegistryTag(SourceFileTagName(), AssetImportData->GetSourceData().ToJson(), FAssetRegistryTag::TT_Hidden));
+		Context.AddTag(FAssetRegistryTag("VRM4U", SourceFileTagName().ToString(), FAssetRegistryTag::TT_Hidden));
 	}
-	Super::GetAssetRegistryTags(OutTags);
+	Super::GetAssetRegistryTags(Context);
 }
 
 void UVrmAssetListObject::WaitUntilAsyncPropertyReleased() const {

--- a/Source/VRM4U/Private/VrmBPFunctionLibrary.cpp
+++ b/Source/VRM4U/Private/VrmBPFunctionLibrary.cpp
@@ -1771,7 +1771,10 @@ bool UVrmBPFunctionLibrary::VRMBakeAnim(const USkeletalMeshComponent* skc, const
 #else
 		ase->GetController().SetNumberOfFrames(ase->GetController().ConvertSecondsToFrameNumber(totalTime));
 		//ase->MarkRawDataAsModified();
-		ase->SetUseRawDataOnly(true);
+    
+		// For UE 5.2+, we need to use a different approach instead of SetUseRawDataOnly
+		// The following is the new approach to flag raw data usage
+		ase->CompressedData.CompressedDataStructure = nullptr;
 		ase->FlagDependentAnimationsAsRawDataOnly();
 		ase->UpdateDependentStreamingAnimations();
 #endif

--- a/Source/VRM4U/Public/AnimNode_VrmConstraint.h
+++ b/Source/VRM4U/Public/AnimNode_VrmConstraint.h
@@ -28,12 +28,12 @@ struct VRM4U_API FAnimNode_VrmConstraint : public FAnimNode_SkeletalControlBase
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Skeleton, meta=(PinHiddenByDefault))
 	const UVrmMetaObject *VrmMetaObject = nullptr;
 
-#if	UE_VERSION_OLDER_THAN(5,0,0)
-	TAssetPtr<UVrmMetaObject> VrmMetaObject_Internal = nullptr;
-	TAssetPtr<UVrmAssetListObject> VrmAssetListObject_Internal = nullptr;
+#if UE_VERSION_OLDER_THAN(5,0,0)
+	TAssetPtr<const UVrmMetaObject> VrmMetaObject_Internal = nullptr;
+	TAssetPtr<const UVrmAssetListObject> VrmAssetListObject_Internal = nullptr;
 #else
-	TSoftObjectPtr<UVrmMetaObject> VrmMetaObject_Internal = nullptr;
-	TSoftObjectPtr<UVrmAssetListObject> VrmAssetListObject_Internal = nullptr;
+	TSoftObjectPtr<const UVrmMetaObject> VrmMetaObject_Internal = nullptr;
+	TSoftObjectPtr<const UVrmAssetListObject> VrmAssetListObject_Internal = nullptr;
 #endif
 
 

--- a/Source/VRM4U/Public/AnimNode_VrmSpringBone.h
+++ b/Source/VRM4U/Public/AnimNode_VrmSpringBone.h
@@ -34,12 +34,12 @@ struct VRM4U_API FAnimNode_VrmSpringBone : public FAnimNode_SkeletalControlBase
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Skeleton, meta=(PinHiddenByDefault))
 	const UVrmMetaObject *VrmMetaObject = nullptr;
 
-#if	UE_VERSION_OLDER_THAN(5,0,0)
-	TAssetPtr<UVrmMetaObject> VrmMetaObject_Internal = nullptr;
-	TAssetPtr<UVrmAssetListObject> VrmAssetListObject_Internal = nullptr;
+#if UE_VERSION_OLDER_THAN(5,0,0)
+	TAssetPtr<const UVrmMetaObject> VrmMetaObject_Internal = nullptr;
+	TAssetPtr<const UVrmAssetListObject> VrmAssetListObject_Internal = nullptr;
 #else
-	TSoftObjectPtr<UVrmMetaObject> VrmMetaObject_Internal = nullptr;
-	TSoftObjectPtr<UVrmAssetListObject> VrmAssetListObject_Internal = nullptr;
+	TSoftObjectPtr<const UVrmMetaObject> VrmMetaObject_Internal = nullptr;
+	TSoftObjectPtr<const UVrmAssetListObject> VrmAssetListObject_Internal = nullptr;
 #endif
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Skeleton, meta = (PinHiddenByDefault))

--- a/Source/VRM4U/Public/VrmAssetListObject.h
+++ b/Source/VRM4U/Public/VrmAssetListObject.h
@@ -256,7 +256,7 @@ public:
 #if WITH_EDITOR
 
 
-	virtual void GetAssetRegistryTags(TArray<FAssetRegistryTag>& OutTags) const override;
+	virtual void GetAssetRegistryTags(FAssetRegistryTagsContext Context) const override;
 	// Import data for this 
 	void WaitUntilAsyncPropertyReleased() const;
 

--- a/Source/VRM4U/Public/VrmMetaObject.h
+++ b/Source/VRM4U/Public/VrmMetaObject.h
@@ -355,6 +355,15 @@ struct VRM4U_API FVRMConstraint {
 	FVRMConstraintRotation constraintRotation;
 };
 
+UENUM(BlueprintType)
+enum class EVrmSkeletonType : uint8
+{
+	Auto UMETA(DisplayName = "Auto Detect"),
+	VRM UMETA(DisplayName = "VRM/VRoid"),
+	Mixamo UMETA(DisplayName = "Mixamo"),
+	MetaHuman UMETA(DisplayName = "MetaHuman"),
+	DAZ UMETA(DisplayName = "DAZ")
+};
 
 UCLASS(Blueprintable, BlueprintType)
 class VRM4U_API UVrmMetaObject : public UObject
@@ -369,6 +378,9 @@ public:
 	int GetVRMVersion() const {
 		return Version;
 	}
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
+	EVrmSkeletonType SkeletonType = EVrmSkeletonType::Auto;
 
 	// humanoid name -> model name
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)

--- a/Source/VRM4U/Public/VrmMetaObject.h
+++ b/Source/VRM4U/Public/VrmMetaObject.h
@@ -7,7 +7,8 @@
 #include "VrmMetaObject.generated.h"
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRMSpringMeta{
+struct VRM4U_API FVRMSpringMeta
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -17,11 +18,11 @@ struct VRM4U_API FVRMSpringMeta{
 	float gravityPower = 0.f;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
-	FVector gravityDir = { 0,-1,0 };
+	FVector gravityDir = {0, -1, 0};
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
 	float dragForce = 0.4f;
-	
+
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
 	float hitRadius = 0.f;
 
@@ -42,9 +43,10 @@ struct VRM4U_API FVRMSpringMeta{
 };
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRMSpringColliderData {
+struct VRM4U_API FVRMSpringColliderData
+{
 	GENERATED_BODY()
-		
+
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
 	FVector offset = FVector::ZeroVector;
 
@@ -53,7 +55,8 @@ struct VRM4U_API FVRMSpringColliderData {
 };
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRMColliderGroupMeta {
+struct VRM4U_API FVRMColliderGroupMeta
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -65,7 +68,8 @@ struct VRM4U_API FVRMColliderGroupMeta {
 
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRMColliderMeta {
+struct VRM4U_API FVRMColliderMeta
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -78,7 +82,8 @@ struct VRM4U_API FVRMColliderMeta {
 };
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRM1SpringJointMeta {
+struct VRM4U_API FVRM1SpringJointMeta
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -97,15 +102,15 @@ struct VRM4U_API FVRM1SpringJointMeta {
 	float gravityPower = 1.f;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
-	FVector gravityDir = { 0,-1,0 };
+	FVector gravityDir = {0, -1, 0};
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
 	float dragForce = 0.5f;
-
 };
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRM1SpringMeta {
+struct VRM4U_API FVRM1SpringMeta
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -119,7 +124,8 @@ struct VRM4U_API FVRM1SpringMeta {
 };
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRM1SpringCollider {
+struct VRM4U_API FVRM1SpringCollider
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -143,7 +149,8 @@ struct VRM4U_API FVRM1SpringCollider {
 };
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRM1SpringColliderGroups {
+struct VRM4U_API FVRM1SpringColliderGroups
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -154,7 +161,8 @@ struct VRM4U_API FVRM1SpringColliderGroups {
 };
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRM1SpringBoneMeta {
+struct VRM4U_API FVRM1SpringBoneMeta
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -171,11 +179,12 @@ struct VRM4U_API FVRM1SpringBoneMeta {
 //////
 
 
-
 // BlendShape
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVrmBlendShape{
+struct VRM4U_API FVrmBlendShape
+{
 	GENERATED_BODY()
+
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
 	FString morphTargetName;
@@ -187,35 +196,38 @@ public:
 	FString meshName;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
-	int meshID=0;
+	int meshID = 0;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
-	int shapeIndex=0;
-	
+	int shapeIndex = 0;
+
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
-	int weight=100;
+	int weight = 100;
 };
 
 // BlendShape Material
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVrmBlendShapeMaterialList {
+struct VRM4U_API FVrmBlendShapeMaterialList
+{
 	GENERATED_BODY()
+
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
-		FString materialName;
+	FString materialName;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
-		FString propertyName;
+	FString propertyName;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
-		FLinearColor color = FLinearColor::Black;
+	FLinearColor color = FLinearColor::Black;
 };
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVrmBlendShapeGroup {
+struct VRM4U_API FVrmBlendShapeGroup
+{
 	GENERATED_BODY()
-public:
 
+public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
 	FString name;
 
@@ -238,7 +250,6 @@ public:
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
 	FString overrideMouth;
-
 };
 
 //struct VRM4U_API FBVrmlendShapeGroup {
@@ -246,12 +257,14 @@ public:
 //};
 
 UENUM(BlueprintType)
-enum class EVRMConstraintType : uint8 {
+enum class EVRMConstraintType : uint8
+{
 	None, Roll, Aim, Rotation,
 };
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRMConstraintRoll {
+struct VRM4U_API FVRMConstraintRoll
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -268,7 +281,8 @@ struct VRM4U_API FVRMConstraintRoll {
 };
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRMConstraintAim {
+struct VRM4U_API FVRMConstraintAim
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -285,7 +299,8 @@ struct VRM4U_API FVRMConstraintAim {
 };
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRMConstraintRotation {
+struct VRM4U_API FVRMConstraintRotation
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -299,7 +314,8 @@ struct VRM4U_API FVRMConstraintRotation {
 };
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRMAnimationLookAt {
+struct VRM4U_API FVRMAnimationLookAt
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -310,7 +326,8 @@ struct VRM4U_API FVRMAnimationLookAt {
 };
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRMAnimationExpressionPreset {
+struct VRM4U_API FVRMAnimationExpressionPreset
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -325,7 +342,8 @@ struct VRM4U_API FVRMAnimationExpressionPreset {
 
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRMAnimationMeta {
+struct VRM4U_API FVRMAnimationMeta
+{
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
@@ -333,12 +351,12 @@ struct VRM4U_API FVRMAnimationMeta {
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
 	TArray<FVRMAnimationExpressionPreset> expressionPreset;
-		
 };
 
 
 USTRUCT(Blueprintable, BlueprintType)
-struct VRM4U_API FVRMConstraint {
+struct VRM4U_API FVRMConstraint
+{
 	GENERATED_BODY()
 
 
@@ -365,53 +383,72 @@ enum class EVrmSkeletonType : uint8
 	DAZ UMETA(DisplayName = "DAZ")
 };
 
+USTRUCT(BlueprintType)
+struct VRM4U_API FVrmBoneOverride
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Bone Mapping")
+	FString HumanoidBoneName;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Bone Mapping")
+	FString ModelBoneName;
+};
+
 UCLASS(Blueprintable, BlueprintType)
 class VRM4U_API UVrmMetaObject : public UObject
 {
 	GENERATED_BODY()
-	
+
 public:
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
+	// Basic properties
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Meta")
 	int Version = 0;
 
 	UFUNCTION(BlueprintPure, Category = "VRM4U")
-	int GetVRMVersion() const {
+	int GetVRMVersion() const
+	{
 		return Version;
 	}
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
+	// Skeleton properties
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Skeleton", meta = (DisplayName = "Skeleton Type"))
 	EVrmSkeletonType SkeletonType = EVrmSkeletonType::Auto;
 
-	// humanoid name -> model name
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Skeleton")
+	class USkeletalMesh* SkeletalMesh;
+
+	// Bone mapping properties
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Bone Mapping", meta = (DisplayName = "Humanoid Bone Table"))
 	TMap<FString, FString> humanoidBoneTable;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Bone Mapping",
+		meta = (DisplayName = "Custom Bone Overrides", ToolTip =
+			"Override specific bone mappings regardless of detected skeleton type"))
+	TArray<FVrmBoneOverride> CustomBoneOverrides;
+
+	// Keep the rest of your properties with appropriate categorization
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Blend Shapes")
 	TArray<FVrmBlendShapeGroup> BlendShapeGroup;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics")
 	TArray<FVRMSpringMeta> VRMSpringMeta;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics")
 	FVRM1SpringBoneMeta VRM1SpringBoneMeta;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics")
 	TArray<FVRMColliderMeta> VRMColliderMeta;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics")
 	TArray<FVRMColliderGroupMeta> VRMColliderGroupMeta;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Constraints")
 	TMap<FString, FVRMConstraint> VRMConstraintMeta;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Animation")
 	FVRMAnimationMeta VRMAnimationMeta;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
-	class USkeletalMesh *SkeletalMesh;
-
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Rendering)
-	class UVrmAssetListObject *VrmAssetListObject;
-
-
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Assets")
+	class UVrmAssetListObject* VrmAssetListObject;
 };

--- a/Source/VRM4UCapture/Public/AnimNode_VrmVMC.h
+++ b/Source/VRM4UCapture/Public/AnimNode_VrmVMC.h
@@ -29,11 +29,11 @@ struct VRM4UCAPTURE_API FAnimNode_VrmVMC : public FAnimNode_SkeletalControlBase
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Skeleton, meta=(PinHiddenByDefault))
 	const UVrmMetaObject *VrmMetaObject = nullptr;
 
-#if	UE_VERSION_OLDER_THAN(5,0,0)
+#if	UE_VERSION_OLDER_THAN(5, 0, 0)
 	TAssetPtr<UVrmMetaObject> VrmMetaObject_Internal = nullptr;
 	TAssetPtr<UVrmAssetListObject> VrmAssetListObject_Internal = nullptr;
 #else
-	TSoftObjectPtr<UVrmMetaObject> VrmMetaObject_Internal = nullptr;
+	TSoftObjectPtr<const UVrmMetaObject> VrmMetaObject_Internal = nullptr;
 	TSoftObjectPtr<UVrmAssetListObject> VrmAssetListObject_Internal = nullptr;
 #endif
 

--- a/Source/VRM4UCaptureEditor/Private/AnimGraphNode_VrmVMC.cpp
+++ b/Source/VRM4UCaptureEditor/Private/AnimGraphNode_VrmVMC.cpp
@@ -21,24 +21,34 @@
 UAnimGraphNode_VrmVMC::UAnimGraphNode_VrmVMC(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
-#if	UE_VERSION_OLDER_THAN(5,0,0)
+#if	UE_VERSION_OLDER_THAN(5, 0, 0)
 	CurWidgetMode = (int32)FWidget::WM_Rotate;
 #else
 	CurWidgetMode = UE::Widget::EWidgetMode::WM_Rotate;
 #endif
 }
 
-void UAnimGraphNode_VrmVMC::ValidateAnimNodePostCompile(FCompilerResultsLog& MessageLog, UAnimBlueprintGeneratedClass* CompiledClass, int32 CompiledNodeIndex) {
-
-	if (Node.VrmMetaObject == nullptr) {
+void UAnimGraphNode_VrmVMC::ValidateAnimNodePostCompile(FCompilerResultsLog& MessageLog,
+														UAnimBlueprintGeneratedClass* CompiledClass,
+														int32 CompiledNodeIndex)
+{
+	if (Node.VrmMetaObject == nullptr)
+	{
 		//MessageLog.Warning(*LOCTEXT("VrmNoMetaObject", "@@ - You must set VrmMetaObject").ToString(), this);
-	} else {
-		if (Node.VrmMetaObject->SkeletalMesh) {
-			if (VRMGetSkeleton(Node.VrmMetaObject->SkeletalMesh) != CompiledClass->GetTargetSkeleton()) {
-				MessageLog.Warning(*LOCTEXT("VrmDifferentSkeleton", "@@ - You must set VrmMetaObject has same skeleton").ToString(), this);
+	}
+	else
+	{
+		if (Node.VrmMetaObject->SkeletalMesh)
+		{
+			if (VRMGetSkeleton(Node.VrmMetaObject->SkeletalMesh) != CompiledClass->GetTargetSkeleton())
+			{
+				MessageLog.Warning(
+					*LOCTEXT("VrmDifferentSkeleton", "@@ - You must set VrmMetaObject has same skeleton").ToString(),
+					this);
 			}
 		}
-		if (CompiledClass->GetTargetSkeleton()->GetReferenceSkeleton().GetRawBoneNum() <= 0) {
+		if (CompiledClass->GetTargetSkeleton()->GetReferenceSkeleton().GetRawBoneNum() <= 0)
+		{
 			MessageLog.Warning(*LOCTEXT("VrmNoBone", "@@ - Skeleton bad data").ToString(), this);
 		}
 	}
@@ -51,16 +61,22 @@ void UAnimGraphNode_VrmVMC::ValidateAnimNodeDuringCompilation(USkeleton* ForSkel
 	// Temporary fix where skeleton is not fully loaded during AnimBP compilation and thus virtual bone name check is invalid UE-39499 (NEED FIX) 
 	if (ForSkeleton && !ForSkeleton->HasAnyFlags(RF_NeedPostLoad))
 	{
-		if (Node.VrmMetaObject == nullptr) {
+		if (Node.VrmMetaObject == nullptr)
+		{
 			//MessageLog.Warning(*LOCTEXT("VrmNoMetaObject", "@@ - You must set VrmMetaObject").ToString(), this);
-		} else {
-			if (Node.VrmMetaObject->SkeletalMesh){
-				if (VRMGetSkeleton(Node.VrmMetaObject->SkeletalMesh) != ForSkeleton) {
-			//		MessageLog.Warning(*LOCTEXT("VrmDifferentSkeleton", "@@ - You must set VrmMetaObject has same skeleton").ToString(), this);
+		}
+		else
+		{
+			if (Node.VrmMetaObject->SkeletalMesh)
+			{
+				if (VRMGetSkeleton(Node.VrmMetaObject->SkeletalMesh) != ForSkeleton)
+				{
+					//		MessageLog.Warning(*LOCTEXT("VrmDifferentSkeleton", "@@ - You must set VrmMetaObject has same skeleton").ToString(), this);
 				}
 			}
-			if (ForSkeleton->GetReferenceSkeleton().GetRawBoneNum() <= 0) {
-			//	MessageLog.Warning(*LOCTEXT("VrmNoBone", "@@ - Skeleton bad data").ToString(), this);
+			if (ForSkeleton->GetReferenceSkeleton().GetRawBoneNum() <= 0)
+			{
+				//	MessageLog.Warning(*LOCTEXT("VrmNoBone", "@@ - Skeleton bad data").ToString(), this);
 			}
 		}
 
@@ -90,7 +106,7 @@ void UAnimGraphNode_VrmVMC::ValidateAnimNodeDuringCompilation(USkeleton* ForSkel
 
 	//if ((Node.TranslationMode == BMM_Ignore) && (Node.RotationMode == BMM_Ignore) && (Node.ScaleMode == BMM_Ignore))
 	{
-	//	MessageLog.Warning(*LOCTEXT("NothingToModify", "@@ - No components to modify selected.  Either Rotation, Translation, or Scale should be set to something other than Ignore").ToString(), this);
+		//	MessageLog.Warning(*LOCTEXT("NothingToModify", "@@ - No components to modify selected.  Either Rotation, Translation, or Scale should be set to something other than Ignore").ToString(), this);
 	}
 
 	Super::ValidateAnimNodeDuringCompilation(ForSkeleton, MessageLog);
@@ -131,7 +147,6 @@ FText UAnimGraphNode_VrmVMC::GetNodeTitle(ENodeTitleType::Type TitleType) const
 
 	return CachedNodeTitles[TitleType];
 	*/
-
 }
 
 //void UAnimGraphNode_VrmVMC::CopyNodeDataToPreviewNode(FAnimNode_Base* InPreviewNode)
@@ -143,14 +158,78 @@ FEditorModeID UAnimGraphNode_VrmVMC::GetEditorMode() const
 	return Super::GetEditorMode();
 }
 
-void UAnimGraphNode_VrmVMC::Draw(FPrimitiveDrawInterface* PDI, USkeletalMeshComponent * PreviewSkelMeshComp) const
+void UAnimGraphNode_VrmVMC::Draw(FPrimitiveDrawInterface* PDI, USkeletalMeshComponent* PreviewSkelMeshComp) const
 {
 	if (PreviewSkelMeshComp)
 	{
-		if (FAnimNode_VrmVMC* ActiveNode = GetActiveInstanceNode<FAnimNode_VrmVMC>(PreviewSkelMeshComp->GetAnimInstance()))
+		if (FAnimNode_VrmVMC* ActiveNode = GetActiveInstanceNode<FAnimNode_VrmVMC>(
+			PreviewSkelMeshComp->GetAnimInstance()))
 		{
-			if (bPreviewLive) {
+			if (bPreviewLive)
+			{
 				//ActiveNode->ConditionalDebugDraw(PDI, PreviewSkelMeshComp, bPreviewForeground);
+			}
+		}
+	}
+}
+
+void UAnimGraphNode_VrmVMC::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+	Super::PostEditChangeProperty(PropertyChangedEvent);
+
+	// Check if the meta object property was changed
+	const FName PropertyName = PropertyChangedEvent.GetPropertyName();
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FAnimNode_VrmVMC, VrmMetaObject))
+	{
+		if (Node.VrmMetaObject && Node.VrmMetaObject->SkeletalMesh)
+		{
+			// Try to automatically populate metadata if needed
+			if (Node.VrmMetaObject->humanoidBoneTable.Num() == 0)
+			{
+				// We need a non-const pointer to modify the meta object
+				UVrmMetaObject* MutableMetaObject = const_cast<UVrmMetaObject*>(Node.VrmMetaObject);
+
+				if (MutableMetaObject)
+				{
+					bool bSuccess = UAutoPopulateVrmMeta::AutoPopulateMetaObject(
+						MutableMetaObject, MutableMetaObject->SkeletalMesh);
+
+					// Create notification about the auto-population result
+					ESkeletonType DetectedType = UAutoPopulateVrmMeta::DetectSkeletonType(
+						MutableMetaObject->SkeletalMesh);
+					FString TypeName;
+					switch (DetectedType)
+					{
+					case ESkeletonType::VRM: TypeName = TEXT("VRM");
+						break;
+					case ESkeletonType::Mixamo: TypeName = TEXT("Mixamo");
+						break;
+					case ESkeletonType::MetaHuman: TypeName = TEXT("MetaHuman");
+						break;
+					case ESkeletonType::DAZ: TypeName = TEXT("DAZ");
+						break;
+					default: TypeName = TEXT("Unknown");
+					}
+
+					int32 MappedBoneCount = Node.VrmMetaObject->humanoidBoneTable.Num();
+					FString Message;
+					if (bSuccess)
+					{
+						Message = FString::Printf(TEXT("VRM4U: Successfully detected %s skeleton and mapped %d bones."),
+												*TypeName, MappedBoneCount);
+					}
+					else
+					{
+						Message = FString::Printf(
+							TEXT(
+								"VRM4U: Detected %s skeleton but could not map all required bones. Check log for details."),
+							*TypeName);
+					}
+
+					FNotificationInfo Info(FText::FromString(Message));
+					Info.ExpireDuration = 5.0f;
+					FSlateNotificationManager::Get().AddNotification(Info);
+				}
 			}
 		}
 	}

--- a/Source/VRM4UCaptureEditor/Private/AnimGraphNode_VrmVMC.h
+++ b/Source/VRM4UCaptureEditor/Private/AnimGraphNode_VrmVMC.h
@@ -12,6 +12,10 @@
 #include "UnrealWidget.h"
 #include "AnimNodeEditMode.h"
 
+#include "Framework/Notifications/NotificationManager.h"
+#include "Widgets/Notifications/SNotificationList.h"
+#include "AutoPopulateVrmMeta.h"
+
 #include "AnimGraphNode_VrmVMC.generated.h" 
 
 class FCompilerResultsLog;
@@ -37,6 +41,8 @@ public:
 	virtual FText GetNodeTitle(ENodeTitleType::Type TitleType) const override;
 	virtual FText GetTooltipText() const override;
 	// End of UEdGraphNode interface
+
+	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
 
 protected:
 	// UAnimGraphNode_Base interface

--- a/Source/VRM4UCaptureEditor/Private/AutoPopulateVrmMeta.cpp
+++ b/Source/VRM4UCaptureEditor/Private/AutoPopulateVrmMeta.cpp
@@ -1,6 +1,4 @@
-﻿// VRM4U Copyright (c) 2021-2024 Haruyoshi Yamamoto. This software is released under the MIT License.
-
-#include "AutoPopulateVrmMeta.h"
+﻿#include "AutoPopulateVrmMeta.h"
 #include "Animation/Skeleton.h"
 #include "Misc/EngineVersionComparison.h"
 #include "VrmMetaObject.h"
@@ -8,487 +6,954 @@
 
 ESkeletonType UAutoPopulateVrmMeta::DetectSkeletonType(USkeletalMesh* InSkeletalMesh)
 {
-    if (!InSkeletalMesh)
-    {
-        return ESkeletonType::Unknown;
-    }
+	if (!InSkeletalMesh)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("DetectSkeletonType: Null skeleton mesh provided"));
+		return ESkeletonType::Unknown;
+	}
 
-    USkeleton* Skeleton = VRMGetSkeleton(InSkeletalMesh);
-    if (!Skeleton)
-    {
-        return ESkeletonType::Unknown;
-    }
+	USkeleton* Skeleton = VRMGetSkeleton(InSkeletalMesh);
+	if (!Skeleton)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("DetectSkeletonType: Could not get skeleton from mesh"));
+		return ESkeletonType::Unknown;
+	}
 
-    // Get bone names to detect skeleton type
-    const FReferenceSkeleton& RefSkeleton = Skeleton->GetReferenceSkeleton();
-    TArray<FName> BoneNames;
-    for (int32 i = 0; i < RefSkeleton.GetNum(); ++i)
-    {
-        BoneNames.Add(RefSkeleton.GetBoneName(i));
-    }
+	// Get bone names to detect skeleton type
+	const FReferenceSkeleton& RefSkeleton = Skeleton->GetReferenceSkeleton();
+	TArray<FName> BoneNames;
+	for (int32 i = 0; i < RefSkeleton.GetNum(); ++i)
+	{
+		BoneNames.Add(RefSkeleton.GetBoneName(i));
+	}
 
-    // Check for Standard MetaHuman (Mixamo-like naming)
-    if (BoneNames.Contains(FName("Hips")) && 
-        BoneNames.Contains(FName("Spine1")) && 
-        BoneNames.Contains(FName("LeftArm")) &&
-        (BoneNames.Contains(FName("LeftEye")) || BoneNames.Contains(FName("RightEye"))))
-    {
-        return ESkeletonType::MetaHuman;
-    }
+	// Check for VRM specific bones
+	if (BoneNames.Contains(FName("J_Bip_C_Hips")) ||
+		BoneNames.Contains(FName("vrm_hips")) ||
+		BoneNames.Contains(FName("J_Bip_L_UpperArm")) ||
+		BoneNames.Contains(FName("J_Adj_L_FaceEye")))
+	{
+		UE_LOG(LogTemp, Log, TEXT("Detected VRM skeleton type"));
+		return ESkeletonType::VRM;
+	}
 
-    // Check for Epic-style MetaHuman
-    if (BoneNames.Contains(FName("pelvis")) && 
-        BoneNames.Contains(FName("spine_01")) && 
-        BoneNames.Contains(FName("clavicle_l")))
-    {
-        return ESkeletonType::MetaHuman;
-    }
+	// Check for Standard MetaHuman (Mixamo-like naming)
+	if (BoneNames.Contains(FName("Hips")) &&
+		BoneNames.Contains(FName("Spine1")) &&
+		BoneNames.Contains(FName("LeftArm")) &&
+		(BoneNames.Contains(FName("LeftEye")) || BoneNames.Contains(FName("RightEye"))))
+	{
+		UE_LOG(LogTemp, Log, TEXT("Detected MetaHuman skeleton type (standard naming)"));
+		return ESkeletonType::MetaHuman;
+	}
 
-    // Check for Mixamo specific bones
-    if (BoneNames.Contains(FName("Hips")) && 
-        BoneNames.Contains(FName("Spine")) && 
-        BoneNames.Contains(FName("LeftArm")))
-    {
-        return ESkeletonType::Mixamo;
-    }
+	// Check for Epic-style MetaHuman
+	if (BoneNames.Contains(FName("pelvis")) &&
+		BoneNames.Contains(FName("spine_01")) &&
+		BoneNames.Contains(FName("clavicle_l")))
+	{
+		UE_LOG(LogTemp, Log, TEXT("Detected MetaHuman skeleton type (Epic naming)"));
+		return ESkeletonType::MetaHuman;
+	}
 
-    // Check for DAZ specific bones
-    if (BoneNames.Contains(FName("hip")) && 
-        BoneNames.Contains(FName("abdomen")) && 
-        BoneNames.Contains(FName("lShldr")))
-    {
-        return ESkeletonType::DAZ;
-    }
+	// Check for Mixamo specific bones
+	if (BoneNames.Contains(FName("Hips")) &&
+		BoneNames.Contains(FName("Spine")) &&
+		BoneNames.Contains(FName("LeftArm")))
+	{
+		UE_LOG(LogTemp, Log, TEXT("Detected Mixamo skeleton type"));
+		return ESkeletonType::Mixamo;
+	}
 
-    // Check for VRM specific bones
-    if (BoneNames.Contains(FName("J_Bip_C_Hips")) || 
-        BoneNames.Contains(FName("vrm_hips")))
-    {
-        return ESkeletonType::VRM;
-    }
+	// Check for DAZ specific bones
+	if (BoneNames.Contains(FName("hip")) &&
+		BoneNames.Contains(FName("abdomen")) &&
+		BoneNames.Contains(FName("lShldr")))
+	{
+		UE_LOG(LogTemp, Log, TEXT("Detected DAZ skeleton type"));
+		return ESkeletonType::DAZ;
+	}
 
-    return ESkeletonType::Unknown;
+	UE_LOG(LogTemp, Warning, TEXT("Could not detect skeleton type"));
+	return ESkeletonType::Unknown;
 }
 
 bool UAutoPopulateVrmMeta::AutoPopulateMetaObject(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh)
 {
-    if (!InMetaObject || !InSkeletalMesh)
+	if (!InMetaObject)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AutoPopulateMetaObject: Null VrmMetaObject provided"));
+		return false;
+	}
+
+	if (!InSkeletalMesh)
+	{
+		UE_LOG(LogTemp, Error, TEXT("AutoPopulateMetaObject: Null SkeletalMesh provided"));
+		return false;
+	}
+
+	// Set the skeletal mesh first
+	InMetaObject->SkeletalMesh = InSkeletalMesh;
+
+	// Determine skeleton type based on preference or auto-detection
+	ESkeletonType SkeletonType = ESkeletonType::Unknown;
+
+	if (InMetaObject->SkeletonType == EVrmSkeletonType::Auto)
+	{
+		// Auto detect
+		SkeletonType = DetectSkeletonType(InSkeletalMesh);
+		if (SkeletonType == ESkeletonType::Unknown)
+		{
+			UE_LOG(LogTemp, Warning, TEXT("Failed to auto-detect skeleton type, no mapping will be applied"));
+		}
+		else
+		{
+			FString TypeName;
+			switch (SkeletonType)
+			{
+			case ESkeletonType::VRM: TypeName = TEXT("VRM");
+				break;
+			case ESkeletonType::Mixamo: TypeName = TEXT("Mixamo");
+				break;
+			case ESkeletonType::MetaHuman: TypeName = TEXT("MetaHuman");
+				break;
+			case ESkeletonType::DAZ: TypeName = TEXT("DAZ");
+				break;
+			default: TypeName = TEXT("Unknown");
+			}
+			UE_LOG(LogTemp, Log, TEXT("Auto-detected skeleton type: %s"), *TypeName);
+		}
+	}
+	else
+	{
+		// Use the user-specified type
+		switch (InMetaObject->SkeletonType)
+		{
+		case EVrmSkeletonType::VRM:
+			SkeletonType = ESkeletonType::VRM;
+			UE_LOG(LogTemp, Log, TEXT("Using user-specified skeleton type: VRM"));
+			break;
+		case EVrmSkeletonType::Mixamo:
+			SkeletonType = ESkeletonType::Mixamo;
+			UE_LOG(LogTemp, Log, TEXT("Using user-specified skeleton type: Mixamo"));
+			break;
+		case EVrmSkeletonType::MetaHuman:
+			SkeletonType = ESkeletonType::MetaHuman;
+			UE_LOG(LogTemp, Log, TEXT("Using user-specified skeleton type: MetaHuman"));
+			break;
+		case EVrmSkeletonType::DAZ:
+			SkeletonType = ESkeletonType::DAZ;
+			UE_LOG(LogTemp, Log, TEXT("Using user-specified skeleton type: DAZ"));
+			break;
+		default:
+			SkeletonType = ESkeletonType::Unknown;
+			UE_LOG(LogTemp, Warning, TEXT("Invalid user-specified skeleton type"));
+			break;
+		}
+	}
+
+	// Based on the determined type, populate the bone mappings
+	bool bSuccess = false;
+	switch (SkeletonType)
+	{
+	case ESkeletonType::Mixamo:
+		bSuccess = PopulateForMixamo(InMetaObject, InSkeletalMesh);
+		break;
+	case ESkeletonType::MetaHuman:
+		bSuccess = PopulateForMetaHuman(InMetaObject, InSkeletalMesh);
+		break;
+	case ESkeletonType::DAZ:
+		bSuccess = PopulateForDAZ(InMetaObject, InSkeletalMesh);
+		break;
+	case ESkeletonType::VRM:
+		bSuccess = PopulateForVRM(InMetaObject, InSkeletalMesh);
+		break;
+	default:
+		UE_LOG(LogTemp, Warning, TEXT("No skeleton type identified for bone mapping"));
+		return false;
+	}
+
+	// Apply custom bone overrides (implementation for Improvement #4)
+	ApplyCustomBoneOverrides(InMetaObject, InSkeletalMesh);
+
+	if (bSuccess)
+	{
+		UE_LOG(LogTemp, Log, TEXT("Successfully mapped %d bones for skeleton"), InMetaObject->humanoidBoneTable.Num());
+	}
+	else
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Failed to map bones for %s skeleton type"),
+				SkeletonType == ESkeletonType::VRM ? TEXT("VRM") :
+				SkeletonType == ESkeletonType::Mixamo ? TEXT("Mixamo") :
+				SkeletonType == ESkeletonType::MetaHuman ? TEXT("MetaHuman") :
+				SkeletonType == ESkeletonType::DAZ ? TEXT("DAZ") : TEXT("Unknown"));
+	}
+
+	return bSuccess;
+}
+
+bool UAutoPopulateVrmMeta::PopulateForVRM(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh)
+{
+    if (!InMetaObject)
     {
+        UE_LOG(LogTemp, Error, TEXT("PopulateForVRM: Null meta object"));
         return false;
     }
 
-    // Set the skeletal mesh first
-    InMetaObject->SkeletalMesh = InSkeletalMesh;
-
-    // Determine skeleton type based on preference or auto-detection
-    ESkeletonType SkeletonType = ESkeletonType::Unknown;
-    
-    if (InMetaObject->SkeletonType == EVrmSkeletonType::Auto)
+    if (!InSkeletalMesh)
     {
-        // Auto detect
-        SkeletonType = DetectSkeletonType(InSkeletalMesh);
+        UE_LOG(LogTemp, Error, TEXT("PopulateForVRM: Null skeletal mesh"));
+        return false;
     }
-    else
+
+    // Clear existing mappings
+    InMetaObject->humanoidBoneTable.Empty();
+
+    // Get skeleton to find available bones
+    USkeleton* Skeleton = VRMGetSkeleton(InSkeletalMesh);
+    if (!Skeleton)
     {
-        // Use the user-specified type
-        switch (InMetaObject->SkeletonType)
+        UE_LOG(LogTemp, Error, TEXT("PopulateForVRM: Could not get skeleton"));
+        return false;
+    }
+
+    const FReferenceSkeleton& RefSkeleton = Skeleton->GetReferenceSkeleton();
+    TSet<FName> AvailableBones;
+    for (int32 i = 0; i < RefSkeleton.GetNum(); ++i)
+    {
+        AvailableBones.Add(RefSkeleton.GetBoneName(i));
+    }
+    
+    UE_LOG(LogTemp, Log, TEXT("VRM mapping: Found %d bones in skeleton"), AvailableBones.Num());
+
+    // Define mappings for VRoid-style prefixed bones with critical flags
+    struct FBoneMapEntry
+    {
+        FString HumanoidName;
+        FString SkeletonName;
+        bool bIsCritical;
+    };
+
+    TArray<FBoneMapEntry> VRMBoneMap = {
+        // Main body - critical bones
+        { TEXT("hips"), TEXT("J_Bip_C_Hips"), true },
+        { TEXT("spine"), TEXT("J_Bip_C_Spine"), true },
+        { TEXT("chest"), TEXT("J_Bip_C_Chest"), true },
+        { TEXT("upperChest"), TEXT("J_Bip_C_UpperChest"), false },
+        { TEXT("neck"), TEXT("J_Bip_C_Neck"), true },
+        { TEXT("head"), TEXT("J_Bip_C_Head"), true },
+        { TEXT("leftEye"), TEXT("J_Adj_L_FaceEye"), false },
+        { TEXT("rightEye"), TEXT("J_Adj_R_FaceEye"), false },
+
+        // Left arm - critical bones
+        { TEXT("leftShoulder"), TEXT("J_Bip_L_Shoulder"), true },
+        { TEXT("leftUpperArm"), TEXT("J_Bip_L_UpperArm"), true },
+        { TEXT("leftLowerArm"), TEXT("J_Bip_L_LowerArm"), true },
+        { TEXT("leftHand"), TEXT("J_Bip_L_Hand"), true },
+
+        // Right arm - critical bones
+        { TEXT("rightShoulder"), TEXT("J_Bip_R_Shoulder"), true },
+        { TEXT("rightUpperArm"), TEXT("J_Bip_R_UpperArm"), true },
+        { TEXT("rightLowerArm"), TEXT("J_Bip_R_LowerArm"), true },
+        { TEXT("rightHand"), TEXT("J_Bip_R_Hand"), true },
+
+        // Left leg - critical bones
+        { TEXT("leftUpperLeg"), TEXT("J_Bip_L_UpperLeg"), true },
+        { TEXT("leftLowerLeg"), TEXT("J_Bip_L_LowerLeg"), true },
+        { TEXT("leftFoot"), TEXT("J_Bip_L_Foot"), true },
+        { TEXT("leftToes"), TEXT("J_Bip_L_ToeBase"), false },
+
+        // Right leg - critical bones
+        { TEXT("rightUpperLeg"), TEXT("J_Bip_R_UpperLeg"), true },
+        { TEXT("rightLowerLeg"), TEXT("J_Bip_R_LowerLeg"), true },
+        { TEXT("rightFoot"), TEXT("J_Bip_R_Foot"), true },
+        { TEXT("rightToes"), TEXT("J_Bip_R_ToeBase"), false },
+
+        // Left fingers - non-critical bones
+        { TEXT("leftThumbProximal"), TEXT("J_Bip_L_Thumb1"), false },
+        { TEXT("leftThumbIntermediate"), TEXT("J_Bip_L_Thumb2"), false },
+        { TEXT("leftThumbDistal"), TEXT("J_Bip_L_Thumb3"), false },
+        { TEXT("leftIndexProximal"), TEXT("J_Bip_L_Index1"), false },
+        { TEXT("leftIndexIntermediate"), TEXT("J_Bip_L_Index2"), false },
+        { TEXT("leftIndexDistal"), TEXT("J_Bip_L_Index3"), false },
+        { TEXT("leftMiddleProximal"), TEXT("J_Bip_L_Middle1"), false },
+        { TEXT("leftMiddleIntermediate"), TEXT("J_Bip_L_Middle2"), false },
+        { TEXT("leftMiddleDistal"), TEXT("J_Bip_L_Middle3"), false },
+        { TEXT("leftRingProximal"), TEXT("J_Bip_L_Ring1"), false },
+        { TEXT("leftRingIntermediate"), TEXT("J_Bip_L_Ring2"), false },
+        { TEXT("leftRingDistal"), TEXT("J_Bip_L_Ring3"), false },
+        { TEXT("leftLittleProximal"), TEXT("J_Bip_L_Little1"), false },
+        { TEXT("leftLittleIntermediate"), TEXT("J_Bip_L_Little2"), false },
+        { TEXT("leftLittleDistal"), TEXT("J_Bip_L_Little3"), false },
+
+        // Right fingers - non-critical bones
+        { TEXT("rightThumbProximal"), TEXT("J_Bip_R_Thumb1"), false },
+        { TEXT("rightThumbIntermediate"), TEXT("J_Bip_R_Thumb2"), false },
+        { TEXT("rightThumbDistal"), TEXT("J_Bip_R_Thumb3"), false },
+        { TEXT("rightIndexProximal"), TEXT("J_Bip_R_Index1"), false },
+        { TEXT("rightIndexIntermediate"), TEXT("J_Bip_R_Index2"), false },
+        { TEXT("rightIndexDistal"), TEXT("J_Bip_R_Index3"), false },
+        { TEXT("rightMiddleProximal"), TEXT("J_Bip_R_Middle1"), false },
+        { TEXT("rightMiddleIntermediate"), TEXT("J_Bip_R_Middle2"), false },
+        { TEXT("rightMiddleDistal"), TEXT("J_Bip_R_Middle3"), false },
+        { TEXT("rightRingProximal"), TEXT("J_Bip_R_Ring1"), false },
+        { TEXT("rightRingIntermediate"), TEXT("J_Bip_R_Ring2"), false },
+        { TEXT("rightRingDistal"), TEXT("J_Bip_R_Ring3"), false },
+        { TEXT("rightLittleProximal"), TEXT("J_Bip_R_Little1"), false },
+        { TEXT("rightLittleIntermediate"), TEXT("J_Bip_R_Little2"), false },
+        { TEXT("rightLittleDistal"), TEXT("J_Bip_R_Little3"), false }
+    };
+
+    // Track mapping statistics
+    int32 TotalMapped = 0;
+    int32 TotalCritical = 0;
+    int32 MappedCritical = 0;
+    TArray<FString> MissingCriticalBones;
+    bool bUsedPrefixedNames = false;
+    bool bUsedBasicNames = false;
+    bool bUsedVrmPrefixedNames = false;
+
+    // First try with VRoid's prefixed naming convention
+    for (const FBoneMapEntry& Entry : VRMBoneMap)
+    {
+        if (Entry.bIsCritical)
         {
-        case EVrmSkeletonType::VRM:
-            SkeletonType = ESkeletonType::VRM;
-            break;
-        case EVrmSkeletonType::Mixamo:
-            SkeletonType = ESkeletonType::Mixamo;
-            break;
-        case EVrmSkeletonType::MetaHuman:
-            SkeletonType = ESkeletonType::MetaHuman;
-            break;
-        case EVrmSkeletonType::DAZ:
-            SkeletonType = ESkeletonType::DAZ;
-            break;
-        default:
-            SkeletonType = ESkeletonType::Unknown;
-            break;
+            TotalCritical++;
+        }
+
+        if (AvailableBones.Contains(*Entry.SkeletonName))
+        {
+            InMetaObject->humanoidBoneTable.Add(Entry.HumanoidName, Entry.SkeletonName);
+            TotalMapped++;
+            bUsedPrefixedNames = true;
+            
+            if (Entry.bIsCritical)
+            {
+                MappedCritical++;
+            }
+        }
+        else if (Entry.bIsCritical)
+        {
+            MissingCriticalBones.Add(Entry.HumanoidName + TEXT(" (") + Entry.SkeletonName + TEXT(")"));
         }
     }
-    
-    // Based on the determined type, populate the bone mappings
-    switch (SkeletonType)
+
+    // If no or few mappings were found, try standard VRM bone names as fallback
+    if (TotalMapped < TotalCritical / 2)
     {
-    case ESkeletonType::Mixamo:
-        return PopulateForMixamo(InMetaObject, InSkeletalMesh);
-    case ESkeletonType::MetaHuman:
-        return PopulateForMetaHuman(InMetaObject, InSkeletalMesh);
-    case ESkeletonType::DAZ:
-        return PopulateForDAZ(InMetaObject, InSkeletalMesh);
-    case ESkeletonType::VRM:
-        // VRM already works natively, no need to populate
-            return true;
-    default:
-        return false;
+        UE_LOG(LogTemp, Log, TEXT("VRM mapping: Prefixed naming convention failed, trying standard VRM names"));
+        
+        // Reset mapping statistics
+        InMetaObject->humanoidBoneTable.Empty();
+        TotalMapped = 0;
+        MappedCritical = 0;
+        MissingCriticalBones.Empty();
+        
+        // Try with base names
+        for (const FBoneMapEntry& Entry : VRMBoneMap)
+        {
+            if (AvailableBones.Contains(*Entry.HumanoidName))
+            {
+                InMetaObject->humanoidBoneTable.Add(Entry.HumanoidName, Entry.HumanoidName);
+                TotalMapped++;
+                bUsedBasicNames = true;
+                
+                if (Entry.bIsCritical)
+                {
+                    MappedCritical++;
+                }
+            }
+            else 
+            {
+                // Try with "vrm_" prefix
+                FString VrmPrefixedName = FString::Printf(TEXT("vrm_%s"), *Entry.HumanoidName);
+                if (AvailableBones.Contains(*VrmPrefixedName))
+                {
+                    InMetaObject->humanoidBoneTable.Add(Entry.HumanoidName, VrmPrefixedName);
+                    TotalMapped++;
+                    bUsedVrmPrefixedNames = true;
+                    
+                    if (Entry.bIsCritical)
+                    {
+                        MappedCritical++;
+                    }
+                }
+                else if (Entry.bIsCritical)
+                {
+                    MissingCriticalBones.Add(Entry.HumanoidName);
+                }
+            }
+        }
     }
+
+    // Log mapping results
+    if (bUsedPrefixedNames)
+    {
+        UE_LOG(LogTemp, Log, TEXT("VRM mapping: Used VRoid prefixed naming convention"));
+    }
+    else if (bUsedBasicNames)
+    {
+        UE_LOG(LogTemp, Log, TEXT("VRM mapping: Used basic VRM bone names"));
+    }
+    else if (bUsedVrmPrefixedNames)
+    {
+        UE_LOG(LogTemp, Log, TEXT("VRM mapping: Used 'vrm_' prefixed bone names"));
+    }
+    
+    UE_LOG(LogTemp, Log, TEXT("VRM mapping: Successfully mapped %d of %d bones (%d of %d critical bones)"), 
+           TotalMapped, VRMBoneMap.Num(), MappedCritical, TotalCritical);
+    
+    if (MissingCriticalBones.Num() > 0)
+    {
+        FString MissingBonesStr = FString::Join(MissingCriticalBones, TEXT(", "));
+        UE_LOG(LogTemp, Warning, TEXT("Missing critical bones: %s"), *MissingBonesStr);
+    }
+
+    // Success if we mapped at least one bone, with better results if we mapped all critical bones
+    if (TotalMapped > 0)
+    {
+        if (MappedCritical == TotalCritical)
+        {
+            UE_LOG(LogTemp, Log, TEXT("VRM mapping: All critical bones mapped successfully"));
+        }
+        else
+        {
+            UE_LOG(LogTemp, Warning, TEXT("VRM mapping: Some critical bones could not be mapped (%d/%d)"), 
+                  MappedCritical, TotalCritical);
+        }
+        return true;
+    }
+    
+    UE_LOG(LogTemp, Error, TEXT("VRM mapping: Failed to map any bones"));
+    return false;
 }
 
 bool UAutoPopulateVrmMeta::PopulateForMixamo(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh)
 {
-    if (!InMetaObject)
-    {
-        return false;
-    }
+	if (!InMetaObject)
+	{
+		UE_LOG(LogTemp, Error, TEXT("PopulateForMixamo: Null meta object"));
+		return false;
+	}
 
-    // Clear existing mappings
-    InMetaObject->humanoidBoneTable.Empty();
+	if (!InSkeletalMesh)
+	{
+		UE_LOG(LogTemp, Error, TEXT("PopulateForMixamo: Null skeletal mesh"));
+		return false;
+	}
 
-    // Add Mixamo bone mappings
-    InMetaObject->humanoidBoneTable.Add(TEXT("hips"), TEXT("Hips"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("spine"), TEXT("Spine"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("chest"), TEXT("Spine2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("neck"), TEXT("Neck"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("head"), TEXT("Head"));
-    
-    // Left arm
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftShoulder"), TEXT("LeftShoulder"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperArm"), TEXT("LeftArm"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerArm"), TEXT("LeftForeArm"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftHand"), TEXT("LeftHand"));
-    
-    // Right arm
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightShoulder"), TEXT("RightShoulder"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperArm"), TEXT("RightArm"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerArm"), TEXT("RightForeArm"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightHand"), TEXT("RightHand"));
-    
-    // Left leg
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperLeg"), TEXT("LeftUpLeg"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerLeg"), TEXT("LeftLeg"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftFoot"), TEXT("LeftFoot"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftToes"), TEXT("LeftToeBase"));
-    
-    // Right leg
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperLeg"), TEXT("RightUpLeg"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerLeg"), TEXT("RightLeg"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightFoot"), TEXT("RightFoot"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightToes"), TEXT("RightToeBase"));
-    
-    // Left fingers
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbProximal"), TEXT("LeftHandThumb1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbIntermediate"), TEXT("LeftHandThumb2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbDistal"), TEXT("LeftHandThumb3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexProximal"), TEXT("LeftHandIndex1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexIntermediate"), TEXT("LeftHandIndex2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexDistal"), TEXT("LeftHandIndex3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleProximal"), TEXT("LeftHandMiddle1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleIntermediate"), TEXT("LeftHandMiddle2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleDistal"), TEXT("LeftHandMiddle3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingProximal"), TEXT("LeftHandRing1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingIntermediate"), TEXT("LeftHandRing2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingDistal"), TEXT("LeftHandRing3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleProximal"), TEXT("LeftHandPinky1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleIntermediate"), TEXT("LeftHandPinky2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleDistal"), TEXT("LeftHandPinky3"));
-    
-    // Right fingers
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbProximal"), TEXT("RightHandThumb1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbIntermediate"), TEXT("RightHandThumb2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbDistal"), TEXT("RightHandThumb3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexProximal"), TEXT("RightHandIndex1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexIntermediate"), TEXT("RightHandIndex2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexDistal"), TEXT("RightHandIndex3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleProximal"), TEXT("RightHandMiddle1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleIntermediate"), TEXT("RightHandMiddle2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleDistal"), TEXT("RightHandMiddle3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingProximal"), TEXT("RightHandRing1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingIntermediate"), TEXT("RightHandRing2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingDistal"), TEXT("RightHandRing3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleProximal"), TEXT("RightHandPinky1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleIntermediate"), TEXT("RightHandPinky2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleDistal"), TEXT("RightHandPinky3"));
+	// Clear existing mappings
+	InMetaObject->humanoidBoneTable.Empty();
 
-    return true;
+	// Get skeleton to find available bones
+	USkeleton* Skeleton = VRMGetSkeleton(InSkeletalMesh);
+	if (!Skeleton)
+	{
+		UE_LOG(LogTemp, Error, TEXT("PopulateForMixamo: Could not get skeleton"));
+		return false;
+	}
+
+	const FReferenceSkeleton& RefSkeleton = Skeleton->GetReferenceSkeleton();
+	TSet<FName> AvailableBones;
+	for (int32 i = 0; i < RefSkeleton.GetNum(); ++i)
+	{
+		AvailableBones.Add(RefSkeleton.GetBoneName(i));
+	}
+
+	// Define all expected Mixamo bone mappings
+	struct FBoneMapEntry
+	{
+		FString HumanoidName;
+		FString MixamoName;
+		bool bIsCritical; // Is this bone critical for the animation to work properly?
+	};
+
+	TArray<FBoneMapEntry> BoneMap = {
+		// Main body - critical bones
+		{TEXT("hips"), TEXT("Hips"), true},
+		{TEXT("spine"), TEXT("Spine"), true},
+		{TEXT("chest"), TEXT("Spine2"), true},
+		{TEXT("neck"), TEXT("Neck"), true},
+		{TEXT("head"), TEXT("Head"), true},
+
+		// Left arm - critical bones
+		{TEXT("leftShoulder"), TEXT("LeftShoulder"), true},
+		{TEXT("leftUpperArm"), TEXT("LeftArm"), true},
+		{TEXT("leftLowerArm"), TEXT("LeftForeArm"), true},
+		{TEXT("leftHand"), TEXT("LeftHand"), true},
+
+		// Right arm - critical bones
+		{TEXT("rightShoulder"), TEXT("RightShoulder"), true},
+		{TEXT("rightUpperArm"), TEXT("RightArm"), true},
+		{TEXT("rightLowerArm"), TEXT("RightForeArm"), true},
+		{TEXT("rightHand"), TEXT("RightHand"), true},
+
+		// Left leg - critical bones
+		{TEXT("leftUpperLeg"), TEXT("LeftUpLeg"), true},
+		{TEXT("leftLowerLeg"), TEXT("LeftLeg"), true},
+		{TEXT("leftFoot"), TEXT("LeftFoot"), true},
+		{TEXT("leftToes"), TEXT("LeftToeBase"), false},
+
+		// Right leg - critical bones
+		{TEXT("rightUpperLeg"), TEXT("RightUpLeg"), true},
+		{TEXT("rightLowerLeg"), TEXT("RightLeg"), true},
+		{TEXT("rightFoot"), TEXT("RightFoot"), true},
+		{TEXT("rightToes"), TEXT("RightToeBase"), false},
+
+		// Left fingers - non-critical bones
+		{TEXT("leftThumbProximal"), TEXT("LeftHandThumb1"), false},
+		{TEXT("leftThumbIntermediate"), TEXT("LeftHandThumb2"), false},
+		{TEXT("leftThumbDistal"), TEXT("LeftHandThumb3"), false},
+		{TEXT("leftIndexProximal"), TEXT("LeftHandIndex1"), false},
+		{TEXT("leftIndexIntermediate"), TEXT("LeftHandIndex2"), false},
+		{TEXT("leftIndexDistal"), TEXT("LeftHandIndex3"), false},
+		{TEXT("leftMiddleProximal"), TEXT("LeftHandMiddle1"), false},
+		{TEXT("leftMiddleIntermediate"), TEXT("LeftHandMiddle2"), false},
+		{TEXT("leftMiddleDistal"), TEXT("LeftHandMiddle3"), false},
+		{TEXT("leftRingProximal"), TEXT("LeftHandRing1"), false},
+		{TEXT("leftRingIntermediate"), TEXT("LeftHandRing2"), false},
+		{TEXT("leftRingDistal"), TEXT("LeftHandRing3"), false},
+		{TEXT("leftLittleProximal"), TEXT("LeftHandPinky1"), false},
+		{TEXT("leftLittleIntermediate"), TEXT("LeftHandPinky2"), false},
+		{TEXT("leftLittleDistal"), TEXT("LeftHandPinky3"), false},
+
+		// Right fingers - non-critical bones
+		{TEXT("rightThumbProximal"), TEXT("RightHandThumb1"), false},
+		{TEXT("rightThumbIntermediate"), TEXT("RightHandThumb2"), false},
+		{TEXT("rightThumbDistal"), TEXT("RightHandThumb3"), false},
+		{TEXT("rightIndexProximal"), TEXT("RightHandIndex1"), false},
+		{TEXT("rightIndexIntermediate"), TEXT("RightHandIndex2"), false},
+		{TEXT("rightIndexDistal"), TEXT("RightHandIndex3"), false},
+		{TEXT("rightMiddleProximal"), TEXT("RightHandMiddle1"), false},
+		{TEXT("rightMiddleIntermediate"), TEXT("RightHandMiddle2"), false},
+		{TEXT("rightMiddleDistal"), TEXT("RightHandMiddle3"), false},
+		{TEXT("rightRingProximal"), TEXT("RightHandRing1"), false},
+		{TEXT("rightRingIntermediate"), TEXT("RightHandRing2"), false},
+		{TEXT("rightRingDistal"), TEXT("RightHandRing3"), false},
+		{TEXT("rightLittleProximal"), TEXT("RightHandPinky1"), false},
+		{TEXT("rightLittleIntermediate"), TEXT("RightHandPinky2"), false},
+		{TEXT("rightLittleDistal"), TEXT("RightHandPinky3"), false},
+	};
+
+	// Track mapping statistics
+	int32 TotalMapped = 0;
+	int32 TotalCritical = 0;
+	int32 MappedCritical = 0;
+	TArray<FString> MissingCriticalBones;
+
+	// Process each bone mapping
+	for (const FBoneMapEntry& Entry : BoneMap)
+	{
+		if (Entry.bIsCritical)
+		{
+			TotalCritical++;
+		}
+
+		if (AvailableBones.Contains(*Entry.MixamoName))
+		{
+			InMetaObject->humanoidBoneTable.Add(Entry.HumanoidName, Entry.MixamoName);
+			TotalMapped++;
+
+			if (Entry.bIsCritical)
+			{
+				MappedCritical++;
+			}
+		}
+		else if (Entry.bIsCritical)
+		{
+			MissingCriticalBones.Add(Entry.HumanoidName + TEXT(" (") + Entry.MixamoName + TEXT(")"));
+		}
+	}
+
+	// Log mapping results
+	UE_LOG(LogTemp, Log, TEXT("Mixamo mapping: Successfully mapped %d of %d bones (%d of %d critical bones)"),
+			TotalMapped, BoneMap.Num(), MappedCritical, TotalCritical);
+
+	if (MissingCriticalBones.Num() > 0)
+	{
+		FString MissingBonesStr = FString::Join(MissingCriticalBones, TEXT(", "));
+		UE_LOG(LogTemp, Warning, TEXT("Missing critical bones: %s"), *MissingBonesStr);
+	}
+
+	// Return success if all critical bones were mapped, or at least some bones were mapped
+	return (MappedCritical == TotalCritical) || (TotalMapped > 0);
 }
 
 bool UAutoPopulateVrmMeta::PopulateForMetaHuman(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh)
 {
-    if (!InMetaObject || !InSkeletalMesh)
-    {
-        return false;
-    }
+	if (!InMetaObject)
+	{
+		UE_LOG(LogTemp, Error, TEXT("PopulateForMetaHuman: Null meta object"));
+		return false;
+	}
 
-    // Clear existing mappings
-    InMetaObject->humanoidBoneTable.Empty();
+	if (!InSkeletalMesh)
+	{
+		UE_LOG(LogTemp, Error, TEXT("PopulateForMetaHuman: Null skeletal mesh"));
+		return false;
+	}
 
-    // Get skeleton to determine which naming convention it uses
-    USkeleton* Skeleton = VRMGetSkeleton(InSkeletalMesh);
-    if (!Skeleton) return false;
+	// Clear existing mappings
+	InMetaObject->humanoidBoneTable.Empty();
 
-    const FReferenceSkeleton& RefSkeleton = Skeleton->GetReferenceSkeleton();
-    TArray<FName> BoneNames;
-    for (int32 i = 0; i < RefSkeleton.GetNum(); ++i)
-    {
-        BoneNames.Add(RefSkeleton.GetBoneName(i));
-    }
+	// Get skeleton to determine which naming convention it uses
+	USkeleton* Skeleton = VRMGetSkeleton(InSkeletalMesh);
+	if (!Skeleton)
+	{
+		UE_LOG(LogTemp, Error, TEXT("PopulateForMetaHuman: Could not get skeleton"));
+		return false;
+	}
 
-    // Check if this is a standard MetaHuman (like the one in the provided hierarchy)
-    bool bIsStandardMetaHuman = BoneNames.Contains(FName("Hips")) && 
-                              BoneNames.Contains(FName("Spine1")) && 
-                              BoneNames.Contains(FName("LeftArm"));
+	const FReferenceSkeleton& RefSkeleton = Skeleton->GetReferenceSkeleton();
+	TSet<FName> AvailableBones;
+	for (int32 i = 0; i < RefSkeleton.GetNum(); ++i)
+	{
+		AvailableBones.Add(RefSkeleton.GetBoneName(i));
+	}
 
-    if (bIsStandardMetaHuman)
-    {
-        // Use standard MetaHuman (Mixamo-like) naming
-        // Main body
-        InMetaObject->humanoidBoneTable.Add(TEXT("hips"), TEXT("Hips"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("spine"), TEXT("Spine"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("chest"), TEXT("Spine2"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("neck"), TEXT("Neck"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("head"), TEXT("Head"));
-        
-        // Left arm
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftShoulder"), TEXT("LeftShoulder"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperArm"), TEXT("LeftArm"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerArm"), TEXT("LeftForeArm"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftHand"), TEXT("LeftHand"));
-        
-        // Right arm
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightShoulder"), TEXT("RightShoulder"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperArm"), TEXT("RightArm"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerArm"), TEXT("RightForeArm"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightHand"), TEXT("RightHand"));
-        
-        // Left leg
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperLeg"), TEXT("LeftUpLeg"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerLeg"), TEXT("LeftLeg"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftFoot"), TEXT("LeftFoot"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftToes"), TEXT("LeftToeBase"));
-        
-        // Right leg
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperLeg"), TEXT("RightUpLeg"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerLeg"), TEXT("RightLeg"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightFoot"), TEXT("RightFoot"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightToes"), TEXT("RightToeBase"));
-        
-        // Left fingers
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbProximal"), TEXT("LeftHandThumb1"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbIntermediate"), TEXT("LeftHandThumb2"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbDistal"), TEXT("LeftHandThumb3"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexProximal"), TEXT("LeftHandIndex1"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexIntermediate"), TEXT("LeftHandIndex2"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexDistal"), TEXT("LeftHandIndex3"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleProximal"), TEXT("LeftHandMiddle1"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleIntermediate"), TEXT("LeftHandMiddle2"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleDistal"), TEXT("LeftHandMiddle3"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftRingProximal"), TEXT("LeftHandRing1"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftRingIntermediate"), TEXT("LeftHandRing2"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftRingDistal"), TEXT("LeftHandRing3"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleProximal"), TEXT("LeftHandPinky1"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleIntermediate"), TEXT("LeftHandPinky2"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleDistal"), TEXT("LeftHandPinky3"));
-        
-        // Right fingers
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbProximal"), TEXT("RightHandThumb1"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbIntermediate"), TEXT("RightHandThumb2"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbDistal"), TEXT("RightHandThumb3"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexProximal"), TEXT("RightHandIndex1"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexIntermediate"), TEXT("RightHandIndex2"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexDistal"), TEXT("RightHandIndex3"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleProximal"), TEXT("RightHandMiddle1"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleIntermediate"), TEXT("RightHandMiddle2"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleDistal"), TEXT("RightHandMiddle3"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightRingProximal"), TEXT("RightHandRing1"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightRingIntermediate"), TEXT("RightHandRing2"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightRingDistal"), TEXT("RightHandRing3"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleProximal"), TEXT("RightHandPinky1"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleIntermediate"), TEXT("RightHandPinky2"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleDistal"), TEXT("RightHandPinky3"));
+	UE_LOG(LogTemp, Log, TEXT("MetaHuman mapping: Found %d bones in skeleton"), AvailableBones.Num());
 
-        // Optional eye mappings if they exist
-        if (BoneNames.Contains(FName("LeftEye")))
-        {
-            InMetaObject->humanoidBoneTable.Add(TEXT("leftEye"), TEXT("LeftEye"));
-        }
-        if (BoneNames.Contains(FName("RightEye")))
-        {
-            InMetaObject->humanoidBoneTable.Add(TEXT("rightEye"), TEXT("RightEye"));
-        }
-    }
-    else
-    {
-        // Use Epic skeleton naming convention
-        // Main body
-        InMetaObject->humanoidBoneTable.Add(TEXT("hips"), TEXT("pelvis"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("spine"), TEXT("spine_01"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("chest"), TEXT("spine_03"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("neck"), TEXT("neck_01"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("head"), TEXT("head"));
-        
-        // Left arm
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftShoulder"), TEXT("clavicle_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperArm"), TEXT("upperarm_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerArm"), TEXT("lowerarm_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftHand"), TEXT("hand_l"));
-        
-        // Right arm
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightShoulder"), TEXT("clavicle_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperArm"), TEXT("upperarm_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerArm"), TEXT("lowerarm_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightHand"), TEXT("hand_r"));
-        
-        // Left leg
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperLeg"), TEXT("thigh_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerLeg"), TEXT("calf_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftFoot"), TEXT("foot_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftToes"), TEXT("ball_l"));
-        
-        // Right leg
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperLeg"), TEXT("thigh_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerLeg"), TEXT("calf_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightFoot"), TEXT("foot_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightToes"), TEXT("ball_r"));
-        
-        // Left fingers (MetaHuman has a slightly different naming convention)
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbProximal"), TEXT("thumb_01_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbIntermediate"), TEXT("thumb_02_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbDistal"), TEXT("thumb_03_l"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexProximal"), TEXT("index_01_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexIntermediate"), TEXT("index_02_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexDistal"), TEXT("index_03_l"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleProximal"), TEXT("middle_01_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleIntermediate"), TEXT("middle_02_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleDistal"), TEXT("middle_03_l"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftRingProximal"), TEXT("ring_01_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftRingIntermediate"), TEXT("ring_02_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftRingDistal"), TEXT("ring_03_l"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleProximal"), TEXT("pinky_01_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleIntermediate"), TEXT("pinky_02_l"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleDistal"), TEXT("pinky_03_l"));
-        
-        // Right fingers
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbProximal"), TEXT("thumb_01_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbIntermediate"), TEXT("thumb_02_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbDistal"), TEXT("thumb_03_r"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexProximal"), TEXT("index_01_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexIntermediate"), TEXT("index_02_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexDistal"), TEXT("index_03_r"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleProximal"), TEXT("middle_01_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleIntermediate"), TEXT("middle_02_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleDistal"), TEXT("middle_03_r"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightRingProximal"), TEXT("ring_01_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightRingIntermediate"), TEXT("ring_02_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightRingDistal"), TEXT("ring_03_r"));
-        
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleProximal"), TEXT("pinky_01_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleIntermediate"), TEXT("pinky_02_r"));
-        InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleDistal"), TEXT("pinky_03_r"));
-    }
+	// Check if this is a standard MetaHuman (like the one in the provided hierarchy)
+	bool bIsStandardMetaHuman = AvailableBones.Contains(FName("Hips")) &&
+		AvailableBones.Contains(FName("Spine1")) &&
+		AvailableBones.Contains(FName("LeftArm"));
 
-    return true;
+	// Track mapping statistics
+	int32 TotalMapped = 0;
+	int32 TotalCritical = 0;
+	int32 MappedCritical = 0;
+	TArray<FString> MissingCriticalBones;
+
+	// Create mapping data structure like we did for Mixamo
+	struct FBoneMapEntry
+	{
+		FString HumanoidName;
+		FString SkeletonName;
+		bool bIsCritical;
+	};
+
+	TArray<FBoneMapEntry> BoneMap;
+
+	if (bIsStandardMetaHuman)
+	{
+		UE_LOG(LogTemp, Log, TEXT("Using standard MetaHuman (Mixamo-like) naming convention"));
+
+		// Define mappings for standard MetaHuman
+		BoneMap = {
+			// Main body - critical bones
+			{TEXT("hips"), TEXT("Hips"), true},
+			{TEXT("spine"), TEXT("Spine"), true},
+			{TEXT("chest"), TEXT("Spine2"), true},
+			{TEXT("neck"), TEXT("Neck"), true},
+			{TEXT("head"), TEXT("Head"), true},
+
+			// Left arm - critical bones
+			{TEXT("leftShoulder"), TEXT("LeftShoulder"), true},
+			{TEXT("leftUpperArm"), TEXT("LeftArm"), true},
+			{TEXT("leftLowerArm"), TEXT("LeftForeArm"), true},
+			{TEXT("leftHand"), TEXT("LeftHand"), true},
+
+			// Right arm - critical bones
+			{TEXT("rightShoulder"), TEXT("RightShoulder"), true},
+			{TEXT("rightUpperArm"), TEXT("RightArm"), true},
+			{TEXT("rightLowerArm"), TEXT("RightForeArm"), true},
+			{TEXT("rightHand"), TEXT("RightHand"), true},
+
+			// Left leg - critical bones
+			{TEXT("leftUpperLeg"), TEXT("LeftUpLeg"), true},
+			{TEXT("leftLowerLeg"), TEXT("LeftLeg"), true},
+			{TEXT("leftFoot"), TEXT("LeftFoot"), true},
+			{TEXT("leftToes"), TEXT("LeftToeBase"), false},
+
+			// Right leg - critical bones
+			{TEXT("rightUpperLeg"), TEXT("RightUpLeg"), true},
+			{TEXT("rightLowerLeg"), TEXT("RightLeg"), true},
+			{TEXT("rightFoot"), TEXT("RightFoot"), true},
+			{TEXT("rightToes"), TEXT("RightToeBase"), false},
+
+			// Left fingers - non-critical bones
+			{TEXT("leftThumbProximal"), TEXT("LeftHandThumb1"), false},
+			{TEXT("leftThumbIntermediate"), TEXT("LeftHandThumb2"), false},
+			{TEXT("leftThumbDistal"), TEXT("LeftHandThumb3"), false},
+			{TEXT("leftIndexProximal"), TEXT("LeftHandIndex1"), false},
+			{TEXT("leftIndexIntermediate"), TEXT("LeftHandIndex2"), false},
+			{TEXT("leftIndexDistal"), TEXT("LeftHandIndex3"), false},
+			{TEXT("leftMiddleProximal"), TEXT("LeftHandMiddle1"), false},
+			{TEXT("leftMiddleIntermediate"), TEXT("LeftHandMiddle2"), false},
+			{TEXT("leftMiddleDistal"), TEXT("LeftHandMiddle3"), false},
+			{TEXT("leftRingProximal"), TEXT("LeftHandRing1"), false},
+			{TEXT("leftRingIntermediate"), TEXT("LeftHandRing2"), false},
+			{TEXT("leftRingDistal"), TEXT("LeftHandRing3"), false},
+			{TEXT("leftLittleProximal"), TEXT("LeftHandPinky1"), false},
+			{TEXT("leftLittleIntermediate"), TEXT("LeftHandPinky2"), false},
+			{TEXT("leftLittleDistal"), TEXT("LeftHandPinky3"), false},
+
+			// Right fingers - non-critical bones
+			{TEXT("rightThumbProximal"), TEXT("RightHandThumb1"), false},
+			{TEXT("rightThumbIntermediate"), TEXT("RightHandThumb2"), false},
+			{TEXT("rightThumbDistal"), TEXT("RightHandThumb3"), false},
+			{TEXT("rightIndexProximal"), TEXT("RightHandIndex1"), false},
+			{TEXT("rightIndexIntermediate"), TEXT("RightHandIndex2"), false},
+			{TEXT("rightIndexDistal"), TEXT("RightHandIndex3"), false},
+			{TEXT("rightMiddleProximal"), TEXT("RightHandMiddle1"), false},
+			{TEXT("rightMiddleIntermediate"), TEXT("RightHandMiddle2"), false},
+			{TEXT("rightMiddleDistal"), TEXT("RightHandMiddle3"), false},
+			{TEXT("rightRingProximal"), TEXT("RightHandRing1"), false},
+			{TEXT("rightRingIntermediate"), TEXT("RightHandRing2"), false},
+			{TEXT("rightRingDistal"), TEXT("RightHandRing3"), false},
+			{TEXT("rightLittleProximal"), TEXT("RightHandPinky1"), false},
+			{TEXT("rightLittleIntermediate"), TEXT("RightHandPinky2"), false},
+			{TEXT("rightLittleDistal"), TEXT("RightHandPinky3"), false},
+
+			// Eyes - non-critical bones
+			{TEXT("leftEye"), TEXT("LeftEye"), false},
+			{TEXT("rightEye"), TEXT("RightEye"), false},
+		};
+	}
+	else
+	{
+		UE_LOG(LogTemp, Log, TEXT("Using Epic skeleton naming convention for MetaHuman"));
+
+		// Define mappings for Epic-style MetaHuman
+		BoneMap = {
+			// Main body - critical bones
+			{TEXT("hips"), TEXT("pelvis"), true},
+			{TEXT("spine"), TEXT("spine_01"), true},
+			{TEXT("chest"), TEXT("spine_03"), true},
+			{TEXT("neck"), TEXT("neck_01"), true},
+			{TEXT("head"), TEXT("head"), true},
+
+			// Left arm - critical bones
+			{TEXT("leftShoulder"), TEXT("clavicle_l"), true},
+			{TEXT("leftUpperArm"), TEXT("upperarm_l"), true},
+			{TEXT("leftLowerArm"), TEXT("lowerarm_l"), true},
+			{TEXT("leftHand"), TEXT("hand_l"), true},
+
+			// Right arm - critical bones
+			{TEXT("rightShoulder"), TEXT("clavicle_r"), true},
+			{TEXT("rightUpperArm"), TEXT("upperarm_r"), true},
+			{TEXT("rightLowerArm"), TEXT("lowerarm_r"), true},
+			{TEXT("rightHand"), TEXT("hand_r"), true},
+
+			// Left leg - critical bones
+			{TEXT("leftUpperLeg"), TEXT("thigh_l"), true},
+			{TEXT("leftLowerLeg"), TEXT("calf_l"), true},
+			{TEXT("leftFoot"), TEXT("foot_l"), true},
+			{TEXT("leftToes"), TEXT("ball_l"), false},
+
+			// Right leg - critical bones
+			{TEXT("rightUpperLeg"), TEXT("thigh_r"), true},
+			{TEXT("rightLowerLeg"), TEXT("calf_r"), true},
+			{TEXT("rightFoot"), TEXT("foot_r"), true},
+			{TEXT("rightToes"), TEXT("ball_r"), false},
+
+			// Left fingers - non-critical bones
+			{TEXT("leftThumbProximal"), TEXT("thumb_01_l"), false},
+			{TEXT("leftThumbIntermediate"), TEXT("thumb_02_l"), false},
+			{TEXT("leftThumbDistal"), TEXT("thumb_03_l"), false},
+			{TEXT("leftIndexProximal"), TEXT("index_01_l"), false},
+			{TEXT("leftIndexIntermediate"), TEXT("index_02_l"), false},
+			{TEXT("leftIndexDistal"), TEXT("index_03_l"), false},
+			{TEXT("leftMiddleProximal"), TEXT("middle_01_l"), false},
+			{TEXT("leftMiddleIntermediate"), TEXT("middle_02_l"), false},
+			{TEXT("leftMiddleDistal"), TEXT("middle_03_l"), false},
+			{TEXT("leftRingProximal"), TEXT("ring_01_l"), false},
+			{TEXT("leftRingIntermediate"), TEXT("ring_02_l"), false},
+			{TEXT("leftRingDistal"), TEXT("ring_03_l"), false},
+			{TEXT("leftLittleProximal"), TEXT("pinky_01_l"), false},
+			{TEXT("leftLittleIntermediate"), TEXT("pinky_02_l"), false},
+			{TEXT("leftLittleDistal"), TEXT("pinky_03_l"), false},
+
+			// Right fingers - non-critical bones
+			{TEXT("rightThumbProximal"), TEXT("thumb_01_r"), false},
+			{TEXT("rightThumbIntermediate"), TEXT("thumb_02_r"), false},
+			{TEXT("rightThumbDistal"), TEXT("thumb_03_r"), false},
+			{TEXT("rightIndexProximal"), TEXT("index_01_r"), false},
+			{TEXT("rightIndexIntermediate"), TEXT("index_02_r"), false},
+			{TEXT("rightIndexDistal"), TEXT("index_03_r"), false},
+			{TEXT("rightMiddleProximal"), TEXT("middle_01_r"), false},
+			{TEXT("rightMiddleIntermediate"), TEXT("middle_02_r"), false},
+			{TEXT("rightMiddleDistal"), TEXT("middle_03_r"), false},
+			{TEXT("rightRingProximal"), TEXT("ring_01_r"), false},
+			{TEXT("rightRingIntermediate"), TEXT("ring_02_r"), false},
+			{TEXT("rightRingDistal"), TEXT("ring_03_r"), false},
+			{TEXT("rightLittleProximal"), TEXT("pinky_01_r"), false},
+			{TEXT("rightLittleIntermediate"), TEXT("pinky_02_r"), false},
+			{TEXT("rightLittleDistal"), TEXT("pinky_03_r"), false},
+
+			// Check for MetaHuman eye bones with different naming conventions
+			{TEXT("leftEye"), TEXT("eye_l"), false},
+			{TEXT("rightEye"), TEXT("eye_r"), false},
+		};
+	}
+
+	// Process each bone mapping
+	for (const FBoneMapEntry& Entry : BoneMap)
+	{
+		if (Entry.bIsCritical)
+		{
+			TotalCritical++;
+		}
+
+		if (AvailableBones.Contains(*Entry.SkeletonName))
+		{
+			InMetaObject->humanoidBoneTable.Add(Entry.HumanoidName, Entry.SkeletonName);
+			TotalMapped++;
+
+			if (Entry.bIsCritical)
+			{
+				MappedCritical++;
+			}
+		}
+		else if (Entry.bIsCritical)
+		{
+			MissingCriticalBones.Add(Entry.HumanoidName + TEXT(" (") + Entry.SkeletonName + TEXT(")"));
+		}
+	}
+
+	// Log mapping results
+	UE_LOG(LogTemp, Log, TEXT("MetaHuman mapping: Successfully mapped %d of %d bones (%d of %d critical bones)"),
+			TotalMapped, BoneMap.Num(), MappedCritical, TotalCritical);
+
+	if (MissingCriticalBones.Num() > 0)
+	{
+		FString MissingBonesStr = FString::Join(MissingCriticalBones, TEXT(", "));
+		UE_LOG(LogTemp, Warning, TEXT("Missing critical bones: %s"), *MissingBonesStr);
+	}
+
+	// Return success if all critical bones were mapped, or at least some bones were mapped
+	return (MappedCritical == TotalCritical) || (TotalMapped > 0);
 }
 
 bool UAutoPopulateVrmMeta::PopulateForDAZ(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh)
 {
-    if (!InMetaObject)
-    {
-        return false;
-    }
+	if (!InMetaObject)
+	{
+		return false;
+	}
 
-    // Clear existing mappings
-    InMetaObject->humanoidBoneTable.Empty();
+	// Clear existing mappings
+	InMetaObject->humanoidBoneTable.Empty();
 
-    // Add DAZ bone mappings - these names may need to be adjusted based on your specific DAZ export settings
-    // Main body
-    InMetaObject->humanoidBoneTable.Add(TEXT("hips"), TEXT("hip"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("spine"), TEXT("abdomen"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("chest"), TEXT("chest"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("neck"), TEXT("neck"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("head"), TEXT("head"));
-    
-    // Left arm
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftShoulder"), TEXT("lCollar"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperArm"), TEXT("lShldr"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerArm"), TEXT("lForeArm"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftHand"), TEXT("lHand"));
-    
-    // Right arm
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightShoulder"), TEXT("rCollar"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperArm"), TEXT("rShldr"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerArm"), TEXT("rForeArm"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightHand"), TEXT("rHand"));
-    
-    // Left leg
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperLeg"), TEXT("lThigh"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerLeg"), TEXT("lShin"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftFoot"), TEXT("lFoot"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftToes"), TEXT("lToe"));
-    
-    // Right leg
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperLeg"), TEXT("rThigh"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerLeg"), TEXT("rShin"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightFoot"), TEXT("rFoot"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightToes"), TEXT("rToe"));
-    
-    // Left fingers
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbProximal"), TEXT("lThumb1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbIntermediate"), TEXT("lThumb2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbDistal"), TEXT("lThumb3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexProximal"), TEXT("lIndex1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexIntermediate"), TEXT("lIndex2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexDistal"), TEXT("lIndex3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleProximal"), TEXT("lMid1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleIntermediate"), TEXT("lMid2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleDistal"), TEXT("lMid3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingProximal"), TEXT("lRing1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingIntermediate"), TEXT("lRing2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingDistal"), TEXT("lRing3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleProximal"), TEXT("lPinky1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleIntermediate"), TEXT("lPinky2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleDistal"), TEXT("lPinky3"));
-    
-    // Right fingers
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbProximal"), TEXT("rThumb1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbIntermediate"), TEXT("rThumb2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbDistal"), TEXT("rThumb3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexProximal"), TEXT("rIndex1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexIntermediate"), TEXT("rIndex2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexDistal"), TEXT("rIndex3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleProximal"), TEXT("rMid1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleIntermediate"), TEXT("rMid2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleDistal"), TEXT("rMid3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingProximal"), TEXT("rRing1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingIntermediate"), TEXT("rRing2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingDistal"), TEXT("rRing3"));
-    
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleProximal"), TEXT("rPinky1"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleIntermediate"), TEXT("rPinky2"));
-    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleDistal"), TEXT("rPinky3"));
+	// Add DAZ bone mappings - these names may need to be adjusted based on your specific DAZ export settings
+	// Main body
+	InMetaObject->humanoidBoneTable.Add(TEXT("hips"), TEXT("hip"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("spine"), TEXT("abdomen"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("chest"), TEXT("chest"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("neck"), TEXT("neck"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("head"), TEXT("head"));
 
-    return true;
+	// Left arm
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftShoulder"), TEXT("lCollar"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperArm"), TEXT("lShldr"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerArm"), TEXT("lForeArm"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftHand"), TEXT("lHand"));
+
+	// Right arm
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightShoulder"), TEXT("rCollar"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperArm"), TEXT("rShldr"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerArm"), TEXT("rForeArm"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightHand"), TEXT("rHand"));
+
+	// Left leg
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperLeg"), TEXT("lThigh"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerLeg"), TEXT("lShin"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftFoot"), TEXT("lFoot"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftToes"), TEXT("lToe"));
+
+	// Right leg
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperLeg"), TEXT("rThigh"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerLeg"), TEXT("rShin"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightFoot"), TEXT("rFoot"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightToes"), TEXT("rToe"));
+
+	// Left fingers
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbProximal"), TEXT("lThumb1"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbIntermediate"), TEXT("lThumb2"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbDistal"), TEXT("lThumb3"));
+
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexProximal"), TEXT("lIndex1"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexIntermediate"), TEXT("lIndex2"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexDistal"), TEXT("lIndex3"));
+
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleProximal"), TEXT("lMid1"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleIntermediate"), TEXT("lMid2"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleDistal"), TEXT("lMid3"));
+
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftRingProximal"), TEXT("lRing1"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftRingIntermediate"), TEXT("lRing2"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftRingDistal"), TEXT("lRing3"));
+
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleProximal"), TEXT("lPinky1"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleIntermediate"), TEXT("lPinky2"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleDistal"), TEXT("lPinky3"));
+
+	// Right fingers
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbProximal"), TEXT("rThumb1"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbIntermediate"), TEXT("rThumb2"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbDistal"), TEXT("rThumb3"));
+
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexProximal"), TEXT("rIndex1"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexIntermediate"), TEXT("rIndex2"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexDistal"), TEXT("rIndex3"));
+
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleProximal"), TEXT("rMid1"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleIntermediate"), TEXT("rMid2"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleDistal"), TEXT("rMid3"));
+
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightRingProximal"), TEXT("rRing1"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightRingIntermediate"), TEXT("rRing2"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightRingDistal"), TEXT("rRing3"));
+
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleProximal"), TEXT("rPinky1"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleIntermediate"), TEXT("rPinky2"));
+	InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleDistal"), TEXT("rPinky3"));
+
+	return true;
+}
+
+bool UAutoPopulateVrmMeta::ApplyCustomBoneOverrides(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh)
+{
+	if (!InMetaObject || !InSkeletalMesh || InMetaObject->CustomBoneOverrides.Num() == 0)
+	{
+		// No overrides to apply
+		return false;
+	}
+
+	USkeleton* Skeleton = VRMGetSkeleton(InSkeletalMesh);
+	if (!Skeleton)
+	{
+		UE_LOG(LogTemp, Error, TEXT("ApplyCustomBoneOverrides: Could not get skeleton"));
+		return false;
+	}
+
+	const FReferenceSkeleton& RefSkeleton = Skeleton->GetReferenceSkeleton();
+	int32 OverridesApplied = 0;
+
+	for (const FVrmBoneOverride& Override : InMetaObject->CustomBoneOverrides)
+	{
+		if (Override.HumanoidBoneName.IsEmpty() || Override.ModelBoneName.IsEmpty())
+		{
+			continue;
+		}
+
+		// Check if the target bone exists in the skeleton
+		int32 BoneIndex = RefSkeleton.FindBoneIndex(*Override.ModelBoneName);
+		if (BoneIndex != INDEX_NONE)
+		{
+			// Add or update the bone mapping
+			InMetaObject->humanoidBoneTable.Add(Override.HumanoidBoneName, Override.ModelBoneName);
+			UE_LOG(LogTemp, Log, TEXT("Applied custom bone override: %s -> %s"),
+					*Override.HumanoidBoneName, *Override.ModelBoneName);
+			OverridesApplied++;
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("Custom bone override failed: Bone '%s' not found in skeleton"),
+					*Override.ModelBoneName);
+		}
+	}
+
+	UE_LOG(LogTemp, Log, TEXT("Applied %d custom bone overrides"), OverridesApplied);
+	return OverridesApplied > 0;
 }

--- a/Source/VRM4UCaptureEditor/Private/AutoPopulateVrmMeta.cpp
+++ b/Source/VRM4UCaptureEditor/Private/AutoPopulateVrmMeta.cpp
@@ -1,0 +1,345 @@
+﻿// VRM4U Copyright (c) 2021-2024 Haruyoshi Yamamoto. This software is released under the MIT License.
+
+#include "AutoPopulateVrmMeta.h"
+#include "Animation/Skeleton.h"
+#include "Misc/EngineVersionComparison.h"
+#include "VrmMetaObject.h"
+#include "VrmUtil.h"
+
+ESkeletonType UAutoPopulateVrmMeta::DetectSkeletonType(USkeletalMesh* InSkeletalMesh)
+{
+    if (!InSkeletalMesh)
+    {
+        return ESkeletonType::Unknown;
+    }
+
+    USkeleton* Skeleton = VRMGetSkeleton(InSkeletalMesh);
+    if (!Skeleton)
+    {
+        return ESkeletonType::Unknown;
+    }
+
+    // Get bone names to detect skeleton type
+    const FReferenceSkeleton& RefSkeleton = Skeleton->GetReferenceSkeleton();
+    TArray<FName> BoneNames;
+    for (int32 i = 0; i < RefSkeleton.GetNum(); ++i)
+    {
+        BoneNames.Add(RefSkeleton.GetBoneName(i));
+    }
+
+    // Check for MetaHuman specific bones
+    if (BoneNames.Contains(FName("spine_01")) && 
+        BoneNames.Contains(FName("neck_01")) && 
+        BoneNames.Contains(FName("clavicle_l")))
+    {
+        return ESkeletonType::MetaHuman;
+    }
+
+    // Check for Mixamo specific bones
+    if (BoneNames.Contains(FName("Hips")) && 
+        BoneNames.Contains(FName("Spine")) && 
+        BoneNames.Contains(FName("LeftArm")))
+    {
+        return ESkeletonType::Mixamo;
+    }
+
+    // Check for DAZ specific bones (add your detection logic here)
+    // ...
+
+    // Check for VRM specific bones
+    if (BoneNames.Contains(FName("J_Bip_C_Hips")) || 
+        BoneNames.Contains(FName("vrm_hips")))
+    {
+        return ESkeletonType::VRM;
+    }
+
+    return ESkeletonType::Unknown;
+}
+
+bool UAutoPopulateVrmMeta::AutoPopulateMetaObject(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh)
+{
+    if (!InMetaObject || !InSkeletalMesh)
+    {
+        return false;
+    }
+
+    // Set the skeletal mesh first
+    InMetaObject->SkeletalMesh = InSkeletalMesh;
+
+    // Detect skeleton type and call appropriate population method
+    ESkeletonType SkeletonType = DetectSkeletonType(InSkeletalMesh);
+    
+    switch (SkeletonType)
+    {
+    case ESkeletonType::Mixamo:
+        return PopulateForMixamo(InMetaObject, InSkeletalMesh);
+    case ESkeletonType::MetaHuman:
+        return PopulateForMetaHuman(InMetaObject, InSkeletalMesh);
+    case ESkeletonType::DAZ:
+        return PopulateForDAZ(InMetaObject, InSkeletalMesh);
+    case ESkeletonType::VRM:
+        // VRM already works natively, no need to populate
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool UAutoPopulateVrmMeta::PopulateForMixamo(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh)
+{
+    if (!InMetaObject)
+    {
+        return false;
+    }
+
+    // Clear existing mappings
+    InMetaObject->humanoidBoneTable.Empty();
+
+    // Add Mixamo bone mappings
+    InMetaObject->humanoidBoneTable.Add(TEXT("hips"), TEXT("Hips"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("spine"), TEXT("Spine"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("chest"), TEXT("Spine2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("neck"), TEXT("Neck"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("head"), TEXT("Head"));
+    
+    // Left arm
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftShoulder"), TEXT("LeftShoulder"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperArm"), TEXT("LeftArm"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerArm"), TEXT("LeftForeArm"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftHand"), TEXT("LeftHand"));
+    
+    // Right arm
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightShoulder"), TEXT("RightShoulder"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperArm"), TEXT("RightArm"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerArm"), TEXT("RightForeArm"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightHand"), TEXT("RightHand"));
+    
+    // Left leg
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperLeg"), TEXT("LeftUpLeg"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerLeg"), TEXT("LeftLeg"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftFoot"), TEXT("LeftFoot"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftToes"), TEXT("LeftToeBase"));
+    
+    // Right leg
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperLeg"), TEXT("RightUpLeg"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerLeg"), TEXT("RightLeg"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightFoot"), TEXT("RightFoot"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightToes"), TEXT("RightToeBase"));
+    
+    // Left fingers
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbProximal"), TEXT("LeftHandThumb1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbIntermediate"), TEXT("LeftHandThumb2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbDistal"), TEXT("LeftHandThumb3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexProximal"), TEXT("LeftHandIndex1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexIntermediate"), TEXT("LeftHandIndex2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexDistal"), TEXT("LeftHandIndex3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleProximal"), TEXT("LeftHandMiddle1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleIntermediate"), TEXT("LeftHandMiddle2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleDistal"), TEXT("LeftHandMiddle3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingProximal"), TEXT("LeftHandRing1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingIntermediate"), TEXT("LeftHandRing2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingDistal"), TEXT("LeftHandRing3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleProximal"), TEXT("LeftHandPinky1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleIntermediate"), TEXT("LeftHandPinky2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleDistal"), TEXT("LeftHandPinky3"));
+    
+    // Right fingers
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbProximal"), TEXT("RightHandThumb1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbIntermediate"), TEXT("RightHandThumb2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbDistal"), TEXT("RightHandThumb3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexProximal"), TEXT("RightHandIndex1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexIntermediate"), TEXT("RightHandIndex2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexDistal"), TEXT("RightHandIndex3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleProximal"), TEXT("RightHandMiddle1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleIntermediate"), TEXT("RightHandMiddle2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleDistal"), TEXT("RightHandMiddle3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingProximal"), TEXT("RightHandRing1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingIntermediate"), TEXT("RightHandRing2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingDistal"), TEXT("RightHandRing3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleProximal"), TEXT("RightHandPinky1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleIntermediate"), TEXT("RightHandPinky2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleDistal"), TEXT("RightHandPinky3"));
+
+    return true;
+}
+
+bool UAutoPopulateVrmMeta::PopulateForMetaHuman(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh)
+{
+    if (!InMetaObject)
+    {
+        return false;
+    }
+
+    // Clear existing mappings
+    InMetaObject->humanoidBoneTable.Empty();
+
+    // Add MetaHuman bone mappings
+    InMetaObject->humanoidBoneTable.Add(TEXT("hips"), TEXT("pelvis"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("spine"), TEXT("spine_01"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("chest"), TEXT("spine_03"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("neck"), TEXT("neck_01"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("head"), TEXT("head"));
+    
+    // Left arm
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftShoulder"), TEXT("clavicle_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperArm"), TEXT("upperarm_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerArm"), TEXT("lowerarm_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftHand"), TEXT("hand_l"));
+    
+    // Right arm
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightShoulder"), TEXT("clavicle_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperArm"), TEXT("upperarm_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerArm"), TEXT("lowerarm_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightHand"), TEXT("hand_r"));
+    
+    // Left leg
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperLeg"), TEXT("thigh_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerLeg"), TEXT("calf_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftFoot"), TEXT("foot_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftToes"), TEXT("ball_l"));
+    
+    // Right leg
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperLeg"), TEXT("thigh_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerLeg"), TEXT("calf_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightFoot"), TEXT("foot_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightToes"), TEXT("ball_r"));
+    
+    // Left fingers (MetaHuman has a slightly different naming convention)
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbProximal"), TEXT("thumb_01_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbIntermediate"), TEXT("thumb_02_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbDistal"), TEXT("thumb_03_l"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexProximal"), TEXT("index_01_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexIntermediate"), TEXT("index_02_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexDistal"), TEXT("index_03_l"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleProximal"), TEXT("middle_01_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleIntermediate"), TEXT("middle_02_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleDistal"), TEXT("middle_03_l"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingProximal"), TEXT("ring_01_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingIntermediate"), TEXT("ring_02_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingDistal"), TEXT("ring_03_l"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleProximal"), TEXT("pinky_01_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleIntermediate"), TEXT("pinky_02_l"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleDistal"), TEXT("pinky_03_l"));
+    
+    // Right fingers
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbProximal"), TEXT("thumb_01_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbIntermediate"), TEXT("thumb_02_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbDistal"), TEXT("thumb_03_r"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexProximal"), TEXT("index_01_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexIntermediate"), TEXT("index_02_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexDistal"), TEXT("index_03_r"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleProximal"), TEXT("middle_01_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleIntermediate"), TEXT("middle_02_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleDistal"), TEXT("middle_03_r"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingProximal"), TEXT("ring_01_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingIntermediate"), TEXT("ring_02_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingDistal"), TEXT("ring_03_r"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleProximal"), TEXT("pinky_01_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleIntermediate"), TEXT("pinky_02_r"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleDistal"), TEXT("pinky_03_r"));
+
+    return true;
+}
+
+bool UAutoPopulateVrmMeta::PopulateForDAZ(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh)
+{
+    if (!InMetaObject)
+    {
+        return false;
+    }
+
+    // Clear existing mappings
+    InMetaObject->humanoidBoneTable.Empty();
+
+    // Add DAZ bone mappings - these names may need to be adjusted based on your specific DAZ export settings
+    // Main body
+    InMetaObject->humanoidBoneTable.Add(TEXT("hips"), TEXT("hip"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("spine"), TEXT("abdomen"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("chest"), TEXT("chest"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("neck"), TEXT("neck"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("head"), TEXT("head"));
+    
+    // Left arm
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftShoulder"), TEXT("lCollar"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperArm"), TEXT("lShldr"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerArm"), TEXT("lForeArm"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftHand"), TEXT("lHand"));
+    
+    // Right arm
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightShoulder"), TEXT("rCollar"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperArm"), TEXT("rShldr"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerArm"), TEXT("rForeArm"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightHand"), TEXT("rHand"));
+    
+    // Left leg
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftUpperLeg"), TEXT("lThigh"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLowerLeg"), TEXT("lShin"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftFoot"), TEXT("lFoot"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftToes"), TEXT("lToe"));
+    
+    // Right leg
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightUpperLeg"), TEXT("rThigh"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLowerLeg"), TEXT("rShin"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightFoot"), TEXT("rFoot"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightToes"), TEXT("rToe"));
+    
+    // Left fingers
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbProximal"), TEXT("lThumb1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbIntermediate"), TEXT("lThumb2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftThumbDistal"), TEXT("lThumb3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexProximal"), TEXT("lIndex1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexIntermediate"), TEXT("lIndex2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftIndexDistal"), TEXT("lIndex3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleProximal"), TEXT("lMid1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleIntermediate"), TEXT("lMid2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftMiddleDistal"), TEXT("lMid3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingProximal"), TEXT("lRing1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingIntermediate"), TEXT("lRing2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftRingDistal"), TEXT("lRing3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleProximal"), TEXT("lPinky1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleIntermediate"), TEXT("lPinky2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("leftLittleDistal"), TEXT("lPinky3"));
+    
+    // Right fingers
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbProximal"), TEXT("rThumb1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbIntermediate"), TEXT("rThumb2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightThumbDistal"), TEXT("rThumb3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexProximal"), TEXT("rIndex1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexIntermediate"), TEXT("rIndex2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightIndexDistal"), TEXT("rIndex3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleProximal"), TEXT("rMid1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleIntermediate"), TEXT("rMid2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightMiddleDistal"), TEXT("rMid3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingProximal"), TEXT("rRing1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingIntermediate"), TEXT("rRing2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightRingDistal"), TEXT("rRing3"));
+    
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleProximal"), TEXT("rPinky1"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleIntermediate"), TEXT("rPinky2"));
+    InMetaObject->humanoidBoneTable.Add(TEXT("rightLittleDistal"), TEXT("rPinky3"));
+
+    return true;
+}

--- a/Source/VRM4UCaptureEditor/Private/AutoPopulateVrmMeta.h
+++ b/Source/VRM4UCaptureEditor/Private/AutoPopulateVrmMeta.h
@@ -1,0 +1,41 @@
+﻿// VRM4U Copyright (c) 2021-2024 Haruyoshi Yamamoto. This software is released under the MIT License.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "AutoPopulateVrmMeta.generated.h"
+
+class UVrmMetaObject;
+class USkeletalMesh;
+
+UENUM(BlueprintType)
+enum class ESkeletonType : uint8
+{
+	Unknown,
+	VRM,
+	Mixamo,
+	MetaHuman,
+	DAZ
+};
+
+/**
+ * Utility class for auto-populating VrmMetaObject based on skeleton detection
+ */
+UCLASS(BlueprintType)
+class VRM4UCAPTUREEDITOR_API UAutoPopulateVrmMeta : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable, Category = "VRM4U|Utilities")
+	static ESkeletonType DetectSkeletonType(USkeletalMesh* InSkeletalMesh);
+
+	UFUNCTION(BlueprintCallable, Category = "VRM4U|Utilities")
+	static bool AutoPopulateMetaObject(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh);
+
+private:
+	static bool PopulateForMixamo(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh);
+	static bool PopulateForMetaHuman(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh);
+	static bool PopulateForDAZ(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh);
+};

--- a/Source/VRM4UCaptureEditor/Private/AutoPopulateVrmMeta.h
+++ b/Source/VRM4UCaptureEditor/Private/AutoPopulateVrmMeta.h
@@ -1,6 +1,4 @@
-﻿// VRM4U Copyright (c) 2021-2024 Haruyoshi Yamamoto. This software is released under the MIT License.
-
-#pragma once
+﻿#pragma once
 
 #include "CoreMinimal.h"
 #include "UObject/NoExportTypes.h"
@@ -38,4 +36,7 @@ private:
 	static bool PopulateForMixamo(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh);
 	static bool PopulateForMetaHuman(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh);
 	static bool PopulateForDAZ(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh);
+	static bool PopulateForVRM(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh);
+	static bool ApplyCustomBoneOverrides(UVrmMetaObject* InMetaObject, USkeletalMesh* InSkeletalMesh);
+
 };

--- a/Source/VRM4UCaptureEditor/Private/VRM4UCaptureEditor.cpp
+++ b/Source/VRM4UCaptureEditor/Private/VRM4UCaptureEditor.cpp
@@ -5,30 +5,38 @@
 #include "VRM4UCaptureEditorLog.h"
 #include "Modules/ModuleManager.h"
 #include "Internationalization/Internationalization.h"
+#include "PropertyEditorModule.h"
+#include "VrmMetaObject.h"
+#include "VrmMetaObjectCustomization.h"
 
-#define LOCTEXT_NAMESPACE "VRM4UMisc"
+#define LOCTEXT_NAMESPACE "VRM4UCapture"
 
 DEFINE_LOG_CATEGORY(LogVRM4UCaptureEditor);
 
-//////////////////////////////////////////////////////////////////////////
-// FSpriterImporterModule
-
-class FVRM4UCaptureEditorModule : public FDefaultModuleImpl
+void FVRM4UCaptureEditorModule::StartupModule()
 {
-public:
-	virtual void StartupModule() override
+	// Register detail customization
+	FPropertyEditorModule& PropertyModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
+	PropertyModule.RegisterCustomClassLayout(UVrmMetaObject::StaticClass()->GetFName(), 
+		FOnGetDetailCustomizationInstance::CreateStatic(&FVrmMetaObjectCustomization::MakeInstance));
+    
+	// Notify that the module has been loaded
+	UE_LOG(LogVRM4UCaptureEditor, Log, TEXT("VRM4UCaptureEditor module has started"));
+}
+
+void FVRM4UCaptureEditorModule::ShutdownModule()
+{
+	// Unregister detail customization
+	if (FModuleManager::Get().IsModuleLoaded("PropertyEditor"))
 	{
+		FPropertyEditorModule& PropertyModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
+		PropertyModule.UnregisterCustomClassLayout(UVrmMetaObject::StaticClass()->GetFName());
 	}
+    
+	// Notify that the module has been unloaded
+	UE_LOG(LogVRM4UCaptureEditor, Log, TEXT("VRM4UCaptureEditor module has been shut down"));
+}
 
-	virtual void ShutdownModule() override
-	{
-	}
-};
-
-//////////////////////////////////////////////////////////////////////////
-
-IMPLEMENT_MODULE(FVRM4UCaptureEditorModule, VRM4UCaptureEditor);
-
-//////////////////////////////////////////////////////////////////////////
+IMPLEMENT_MODULE(FVRM4UCaptureEditorModule, VRM4UCaptureEditor)
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/VRM4UCaptureEditor/Private/VRM4UCaptureEditor.h
+++ b/Source/VRM4UCaptureEditor/Private/VRM4UCaptureEditor.h
@@ -3,6 +3,12 @@
 #pragma once
 
 #include "CoreMinimal.h"
-//#include "VRMImporterModule.h"
+#include "Modules/ModuleInterface.h"
 
-
+class FVRM4UCaptureEditorModule : public IModuleInterface
+{
+public:
+	/** IModuleInterface implementation */
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+};

--- a/Source/VRM4UCaptureEditor/Private/VrmMetaObjectCustomization.cpp
+++ b/Source/VRM4UCaptureEditor/Private/VrmMetaObjectCustomization.cpp
@@ -1,0 +1,128 @@
+﻿// VRM4U Copyright (c) 2021-2024 Haruyoshi Yamamoto. This software is released under the MIT License.
+
+#include "VrmMetaObjectCustomization.h"
+#include "VrmMetaObject.h"
+#include "AutoPopulateVrmMeta.h"
+#include "DetailLayoutBuilder.h"
+#include "DetailCategoryBuilder.h"
+#include "DetailWidgetRow.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/SBoxPanel.h"
+#include "Framework/Notifications/NotificationManager.h"
+#include "Widgets/Notifications/SNotificationList.h"
+#include "PropertyCustomizationHelpers.h"
+
+#define LOCTEXT_NAMESPACE "VrmMetaObjectCustomization"
+
+TSharedRef<IDetailCustomization> FVrmMetaObjectCustomization::MakeInstance()
+{
+    return MakeShareable(new FVrmMetaObjectCustomization);
+}
+
+void FVrmMetaObjectCustomization::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+    // Get the object being customized
+    TArray<TWeakObjectPtr<UObject>> Objects;
+    DetailBuilder.GetObjectsBeingCustomized(Objects);
+    
+    if (Objects.Num() != 1)
+    {
+        return;
+    }
+    
+    UVrmMetaObject* MetaObject = Cast<UVrmMetaObject>(Objects[0].Get());
+    if (!MetaObject)
+    {
+        return;
+    }
+    
+    // Add a custom row with auto-populate button to the Rendering category
+    IDetailCategoryBuilder& RenderingCategory = DetailBuilder.EditCategory("Rendering", FText::GetEmpty(), ECategoryPriority::Important);
+    
+    RenderingCategory.AddCustomRow(LOCTEXT("AutoPopulateRow", "Auto Populate"))
+        .NameContent()
+        [
+            SNew(STextBlock)
+            .Text(LOCTEXT("AutoPopulateBoneMappings", "Auto-Populate Bone Mappings"))
+            .Font(DetailBuilder.GetDetailFont())
+        ]
+        .ValueContent()
+        .MinDesiredWidth(125.0f)
+        .MaxDesiredWidth(125.0f)
+        [
+            SNew(SButton)
+            .ContentPadding(FMargin(5.0f, 2.0f))
+            .Text(LOCTEXT("AutoPopulateButton", "Auto-Populate"))
+            .ToolTipText(LOCTEXT("AutoPopulateButtonTooltip", "Automatically populate bone mappings based on the detected skeleton type"))
+            .OnClicked(FOnClicked::CreateRaw(this, &FVrmMetaObjectCustomization::OnAutoPopulateClicked, MetaObject))
+        ];
+}
+
+FReply FVrmMetaObjectCustomization::OnAutoPopulateClicked(UVrmMetaObject* MetaObject)
+{
+    if (!MetaObject || !MetaObject->SkeletalMesh)
+    {
+        // Show error notification
+        FNotificationInfo Info(LOCTEXT("NoSkeletalMesh", "Error: VrmMetaObject has no SkeletalMesh assigned"));
+        Info.bUseLargeFont = false;
+        Info.ExpireDuration = 5.0f;
+        FSlateNotificationManager::Get().AddNotification(Info);
+        return FReply::Handled();
+    }
+    
+    ESkeletonType SkeletonType = UAutoPopulateVrmMeta::DetectSkeletonType(MetaObject->SkeletalMesh);
+    
+    if (SkeletonType == ESkeletonType::Unknown)
+    {
+        // Show error notification
+        FNotificationInfo Info(LOCTEXT("UnknownSkeleton", "Error: Could not detect skeleton type"));
+        Info.bUseLargeFont = false;
+        Info.ExpireDuration = 5.0f;
+        FSlateNotificationManager::Get().AddNotification(Info);
+        return FReply::Handled();
+    }
+    
+    bool bSuccess = UAutoPopulateVrmMeta::AutoPopulateMetaObject(MetaObject, MetaObject->SkeletalMesh);
+    
+    if (bSuccess)
+    {
+        // Show success notification
+        FString TypeName;
+        switch (SkeletonType)
+        {
+        case ESkeletonType::Mixamo: TypeName = "Mixamo"; break;
+        case ESkeletonType::MetaHuman: TypeName = "MetaHuman"; break;
+        case ESkeletonType::DAZ: TypeName = "DAZ"; break;
+        case ESkeletonType::VRM: TypeName = "VRM"; break;
+        default: TypeName = "Unknown"; break;
+        }
+        
+        FNotificationInfo Info(FText::Format(
+            LOCTEXT("SuccessfullyPopulated", "Successfully populated bone mappings for {0} skeleton"),
+            FText::FromString(TypeName)
+        ));
+        Info.bUseLargeFont = false;
+        Info.ExpireDuration = 5.0f;
+        FSlateNotificationManager::Get().AddNotification(Info);
+        
+        // Mark the object as dirty so it can be saved
+        MetaObject->Modify();
+        
+        // Force a refresh of the details panel
+        FPropertyEditorModule& PropertyEditorModule = FModuleManager::GetModuleChecked<FPropertyEditorModule>("PropertyEditor");
+        PropertyEditorModule.NotifyCustomizationModuleChanged();
+    }
+    else
+    {
+        // Show error notification
+        FNotificationInfo Info(LOCTEXT("FailedToPopulate", "Error: Failed to populate bone mappings"));
+        Info.bUseLargeFont = false;
+        Info.ExpireDuration = 5.0f;
+        FSlateNotificationManager::Get().AddNotification(Info);
+    }
+    
+    return FReply::Handled();
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/VRM4UCaptureEditor/Private/VrmMetaObjectCustomization.h
+++ b/Source/VRM4UCaptureEditor/Private/VrmMetaObjectCustomization.h
@@ -1,0 +1,28 @@
+﻿// VRM4U Copyright (c) 2021-2024 Haruyoshi Yamamoto. This software is released under the MIT License.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "IDetailCustomization.h"
+#include "PropertyHandle.h"
+#include "DetailWidgetRow.h"
+#include "DetailLayoutBuilder.h"
+
+class UVrmMetaObject;
+
+/**
+ * Customizes the appearance of VrmMetaObject in the property editor
+ */
+class FVrmMetaObjectCustomization : public IDetailCustomization
+{
+public:
+	/** Makes a new instance of this detail layout class for the specified detail view requesting it */
+	static TSharedRef<IDetailCustomization> MakeInstance();
+
+	/** IDetailCustomization interface */
+	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
+
+private:
+	/** Handle auto-populate button click */
+	FReply OnAutoPopulateClicked(UVrmMetaObject* MetaObject);
+};

--- a/Source/VRM4UCaptureEditor/Private/VrmMetaObjectEditorExtension.cpp
+++ b/Source/VRM4UCaptureEditor/Private/VrmMetaObjectEditorExtension.cpp
@@ -1,0 +1,144 @@
+﻿// VRM4U Copyright (c) 2021-2024 Haruyoshi Yamamoto. This software is released under the MIT License.
+
+#include "VrmMetaObjectEditorExtension.h"
+#include "ContentBrowserModule.h"
+#include "IContentBrowserSingleton.h"
+#include "Framework/MultiBox/MultiBoxBuilder.h"
+#include "Framework/Notifications/NotificationManager.h"
+#include "Widgets/Notifications/SNotificationList.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "VrmMetaObject.h"
+#include "AutoPopulateVrmMeta.h"
+#include "EditorStyleSet.h"
+#include "Styling/AppStyle.h"
+
+void FVrmMetaObjectEditorExtension::Register()
+{
+    ExtendContextMenu();
+}
+
+void FVrmMetaObjectEditorExtension::Unregister()
+{
+    // Cleanup if needed
+}
+
+void FVrmMetaObjectEditorExtension::ExtendContextMenu()
+{
+    FContentBrowserModule& ContentBrowserModule = FModuleManager::LoadModuleChecked<FContentBrowserModule>("ContentBrowser");
+    TArray<FContentBrowserMenuExtender_SelectedAssets>& MenuExtenders = ContentBrowserModule.GetAllAssetViewContextMenuExtenders();
+    
+    MenuExtenders.Add(FContentBrowserMenuExtender_SelectedAssets::CreateStatic(&FVrmMetaObjectEditorExtension::OnExtendContentBrowserAssetSelectionMenu));
+}
+
+TSharedRef<FExtender> FVrmMetaObjectEditorExtension::OnExtendContentBrowserAssetSelectionMenu(const TArray<FAssetData>& SelectedAssets)
+{
+    TSharedRef<FExtender> Extender(new FExtender());
+    
+    bool bAnyVrmMetaObjects = false;
+    for (const FAssetData& Asset : SelectedAssets)
+    {
+        if (Asset.AssetClassPath == UVrmMetaObject::StaticClass()->GetClassPathName())
+        {
+            bAnyVrmMetaObjects = true;
+            break;
+        }
+    }
+    
+    if (bAnyVrmMetaObjects)
+    {
+        Extender->AddMenuExtension(
+            "AssetContextAdvancedActions",
+            EExtensionHook::After,
+            nullptr,
+            FMenuExtensionDelegate::CreateLambda([SelectedAssets](FMenuBuilder& MenuBuilder)
+            {
+                MenuBuilder.BeginSection("VrmMetaObjectActions", FText::FromString("VRM Meta Object"));
+                {
+                    MenuBuilder.AddMenuEntry(
+                        FText::FromString("Auto-Populate Bone Mappings"),
+                        FText::FromString("Automatically populate bone mappings based on detected skeleton type"),
+                        FSlateIcon(),
+                        FUIAction(
+                            FExecuteAction::CreateStatic(&FVrmMetaObjectEditorExtension::OnAutoPopulateMenuEntryClicked, SelectedAssets)
+                        )
+                    );
+                }
+                MenuBuilder.EndSection();
+            })
+        );
+    }
+    
+    return Extender;
+}
+
+void FVrmMetaObjectEditorExtension::OnAutoPopulateMenuEntryClicked(TArray<FAssetData> SelectedAssets)
+{
+    for (const FAssetData& Asset : SelectedAssets)
+    {
+        if (Asset.AssetClassPath == UVrmMetaObject::StaticClass()->GetClassPathName())
+        {
+            UVrmMetaObject* MetaObject = Cast<UVrmMetaObject>(Asset.GetAsset());
+            if (MetaObject)
+            {
+                HandleAutoPopulate(MetaObject);
+            }
+        }
+    }
+}
+
+void FVrmMetaObjectEditorExtension::HandleAutoPopulate(UVrmMetaObject* MetaObject)
+{
+    if (!MetaObject || !MetaObject->SkeletalMesh)
+    {
+        // Show error notification
+        FNotificationInfo Info(FText::FromString("Error: VrmMetaObject has no SkeletalMesh assigned"));
+        Info.bUseLargeFont = false;
+        Info.ExpireDuration = 5.0f;
+        FSlateNotificationManager::Get().AddNotification(Info);
+        return;
+    }
+    
+    ESkeletonType SkeletonType = UAutoPopulateVrmMeta::DetectSkeletonType(MetaObject->SkeletalMesh);
+    
+    if (SkeletonType == ESkeletonType::Unknown)
+    {
+        // Show error notification
+        FNotificationInfo Info(FText::FromString("Error: Could not detect skeleton type"));
+        Info.bUseLargeFont = false;
+        Info.ExpireDuration = 5.0f;
+        FSlateNotificationManager::Get().AddNotification(Info);
+        return;
+    }
+    
+    bool bSuccess = UAutoPopulateVrmMeta::AutoPopulateMetaObject(MetaObject, MetaObject->SkeletalMesh);
+    
+    if (bSuccess)
+    {
+        // Show success notification
+        FString TypeName;
+        switch (SkeletonType)
+        {
+        case ESkeletonType::Mixamo: TypeName = "Mixamo"; break;
+        case ESkeletonType::MetaHuman: TypeName = "MetaHuman"; break;
+        case ESkeletonType::DAZ: TypeName = "DAZ"; break;
+        case ESkeletonType::VRM: TypeName = "VRM"; break;
+        default: TypeName = "Unknown"; break;
+        }
+        
+        FNotificationInfo Info(FText::FromString(FString::Printf(TEXT("Successfully populated bone mappings for %s skeleton"), *TypeName)));
+        Info.bUseLargeFont = false;
+        Info.ExpireDuration = 5.0f;
+        FSlateNotificationManager::Get().AddNotification(Info);
+        
+        // Mark the object as dirty so it can be saved
+        MetaObject->Modify();
+    }
+    else
+    {
+        // Show error notification
+        FNotificationInfo Info(FText::FromString("Error: Failed to populate bone mappings"));
+        Info.bUseLargeFont = false;
+        Info.ExpireDuration = 5.0f;
+        FSlateNotificationManager::Get().AddNotification(Info);
+    }
+}

--- a/Source/VRM4UCaptureEditor/Private/VrmMetaObjectEditorExtension.h
+++ b/Source/VRM4UCaptureEditor/Private/VrmMetaObjectEditorExtension.h
@@ -1,0 +1,21 @@
+﻿// VRM4U Copyright (c) 2021-2024 Haruyoshi Yamamoto. This software is released under the MIT License.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "EditorUndoClient.h"
+
+class UVrmMetaObject;
+
+class FVrmMetaObjectEditorExtension : public FEditorUndoClient
+{
+public:
+	static void Register();
+	static void Unregister();
+
+private:
+	static void ExtendContextMenu();
+	static void HandleAutoPopulate(UVrmMetaObject* MetaObject);
+	static TSharedRef<FExtender> OnExtendContentBrowserAssetSelectionMenu(const TArray<FAssetData>& SelectedAssets);
+	static void OnAutoPopulateMenuEntryClicked(TArray<FAssetData> SelectedAssets);
+};

--- a/Source/VRM4UCaptureEditor/VRM4UCaptureEditor.Build.cs
+++ b/Source/VRM4UCaptureEditor/VRM4UCaptureEditor.Build.cs
@@ -9,30 +9,45 @@ public class VRM4UCaptureEditor : ModuleRules
         PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 
         PrivateDependencyModuleNames.AddRange(
-			new string[] {
-				"Core",
-				"CoreUObject",
-                "Engine",
+	        new string[] {
+		        "Core",
+		        "CoreUObject",
+		        "Engine",
 
-				"AnimGraphRuntime",
-				"AnimGraph",
-				"BlueprintGraph",
+		        "AnimGraphRuntime",
+		        "AnimGraph",
+		        "BlueprintGraph",
 
-				"UnrealEd",
-				"AnimationEditMode",
-				"Persona",
+		        "UnrealEd",
+		        "AnimationEditMode",
+		        "Persona",
 
-				"VRM4U",
-				"VRM4UCapture",
-			});
+		        "VRM4U",
+		        "VRM4UCapture", 
+		        "EditorStyle",
+             
+		        // dependencies for the editor extension
+		        "Slate",
+		        "SlateCore",
+		        "ContentBrowser",
+		        "ApplicationCore",
+		        "InputCore",
+		        "AssetRegistry",
+		        "AssetTools",
+		        "PropertyEditor",
+		        "EditorFramework",
+		        "ToolMenus",
+		        "AppFramework",
+	        });
 
-		PrivateIncludePathModuleNames.AddRange(
-			new string[] {
-            });
+        PrivateIncludePathModuleNames.AddRange(
+	        new string[] {
+		        // Include paths only
+	        });
 
-		DynamicallyLoadedModuleNames.AddRange(
-			new string[] {
-			});
+        DynamicallyLoadedModuleNames.AddRange(
+	        new string[] {
+	        });
 
         PrivateIncludePaths.AddRange(
         new string[] {

--- a/VRM4U.uplugin
+++ b/VRM4U.uplugin
@@ -3,7 +3,7 @@
   "Version": 1,
   "VersionName": "1.0",
   "FriendlyName": "VRM4U",
-  "Description": "VRM importer and runtime loader for UE4",
+  "Description": "VRM importer and runtime loader for UE5",
   "Category": "Rendering",
   "CreatedBy": "ruyo",
   "CreatedByURL": "ruyo",


### PR DESCRIPTION
## Description
This PR adds functionality to automatically populate VRM metadata and properly map avatar bones, significantly improving the workflow for VRM avatar setup in Unreal Engine 5.5.

## New Features
- Auto populate mapping bones for Mixamo, Meta-Human, DAZ
- Custom bone mapping if skeletal rig has specialized hierarchy

## Changes
- Add auto populate feature to VRMObject for streamlined metadata configuration
- Implement proper bone mapping structure for accurate skeletal mesh representation
- Enhance frontend UI and backend logic for improved user experience
- Update deprecated API calls for UE 5.5 compatibility

## Testing
Tested with various VRM models to ensure proper bone mapping across different avatar types.